### PR TITLE
Mutable collections

### DIFF
--- a/Bearded.Utilities.sln.DotSettings
+++ b/Bearded.Utilities.sln.DotSettings
@@ -1,4 +1,5 @@
 ﻿<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=ClassNeverInstantiated_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=MemberCanBePrivate_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedAutoPropertyAccessor_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String>
 	<s:String x:Key="/Default/CodeInspection/Highlighting/InspectionSeverities/=UnusedMember_002EGlobal/@EntryIndexedValue">DO_NOT_SHOW</s:String></wpf:ResourceDictionary>

--- a/src/Bearded.Utilities.csproj
+++ b/src/Bearded.Utilities.csproj
@@ -61,7 +61,6 @@
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Algorithms\" />
-    <Folder Include="Collections\" />
     <Folder Include="Data\" />
     <Folder Include="Diagnostics\" />
     <Folder Include="IO\" />
@@ -93,6 +92,10 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Collections\MutableLinkedList.cs" />
+    <Compile Include="Collections\MutableLinkedListEnumerator.cs" />
+    <Compile Include="Collections\MutableLinkedListItem.cs" />
+    <Compile Include="Collections\MutableLinkedListNode.cs" />
     <Compile Include="Input\InputManager.cs" />
     <Compile Include="Core\Do.cs" />
     <Compile Include="Core\Environment.cs" />

--- a/src/Bearded.Utilities.csproj
+++ b/src/Bearded.Utilities.csproj
@@ -92,10 +92,13 @@
     </BootstrapperPackage>
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="Collections\DeletableObjectListEnumerator.cs" />
+    <Compile Include="Collections\IDeletable.cs" />
     <Compile Include="Collections\MutableLinkedList.cs" />
     <Compile Include="Collections\MutableLinkedListEnumerator.cs" />
     <Compile Include="Collections\MutableLinkedListItem.cs" />
     <Compile Include="Collections\MutableLinkedListNode.cs" />
+    <Compile Include="Collections\DeletableObjectList.cs" />
     <Compile Include="Input\InputManager.cs" />
     <Compile Include="Core\Do.cs" />
     <Compile Include="Core\Environment.cs" />

--- a/src/Collections/DeletableObjectList.cs
+++ b/src/Collections/DeletableObjectList.cs
@@ -1,0 +1,159 @@
+﻿using System.Collections.Generic;
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// This class represents a list that automatically removes items that have been deleted as specified by the IDeletable interface.
+    /// It uses a List as backing data structure.
+    /// The backing data structure is automatically compacted after too many deletions, and when there are no active enumerators.
+    /// Enumeration of the list skips all deleted items, and items can be deleted while enumerating.
+    /// Apart from manual removal and forced compaction all operations of this class are armourtised constant time.
+    /// This list is not threadsafe.
+    /// </summary>
+    public sealed class DeletableObjectList<T> : IEnumerable<T>
+        where T : class, IDeletable
+    {
+        #region Fields and Properties
+
+        private readonly List<T> list;
+
+        private int enumerators;
+        private int count;
+        private float emptyFraction { get { return (float)(this.list.Count - this.count) / this.count; } }
+
+        /// <summary>
+        /// Gets or sets the maximmum fraction of deleted objects this list can contain before it compacts the backing data structure.
+        /// The lower the value, the more aggressively and more often is the list compacted.
+        /// A value of 0 compacts as often as possible.
+        /// </summary>
+        public float MaxEmptyFraction { get; set; }
+
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Initializes a new deletable object list.
+        /// </summary>
+        /// <param name="capacity">Initial capacity of the backing data structure.</param>
+        public DeletableObjectList(int capacity = 4)
+        {
+            this.list = new List<T>(capacity);
+            this.MaxEmptyFraction = 0.2f;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Adds an item to this deletable object list.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        public void Add(T item)
+        {
+            this.list.Add(item);
+            this.count++;
+        }
+
+        /// <summary>
+        /// Tries removing a given item from the list.
+        /// This performs a linear search and therefor runs in O(n) time, where n the number of items in the list,
+        /// assuming frequent enumeration or forced compaction.
+        /// This method does not have to be called for items with Deleted set to true. Those items will be removed automatically.
+        /// </summary>
+        /// <param name="item">The item to remove.</param>
+        /// <returns>True if the item was found and removed, false otherwise.</returns>
+        public bool Remove(T item)
+        {
+            var i = this.list.IndexOf(item);
+            if (i == -1)
+                return false;
+            this.ClearBackingArrayIndex(i);
+            this.considerCompacting();
+            return true;
+        }
+
+        internal void ClearBackingArrayIndex(int i)
+        {
+            this.list[i] = null;
+            this.count--;
+        }
+
+        #region Enumeration
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        public IEnumerator<T> GetEnumerator()
+        {
+            return new DeletableObjectListEnumerator<T>(this, this.list);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        internal void RegisterEnumerator()
+        {
+            this.enumerators++;
+        }
+        internal void UnregisterEnumerator()
+        {
+            this.enumerators--;
+            this.considerCompacting();
+        }
+
+        #endregion
+
+        #region Compaction and Trimming
+
+        private void considerCompacting()
+        {
+            if (this.enumerators == 0 &&
+                this.count > 0 &&
+                this.emptyFraction > this.MaxEmptyFraction)
+            {
+                this.compact();
+            }
+        }
+
+        private void compact()
+        {
+            this.list.RemoveAll(t => t == null || t.Deleted);
+            this.count = list.Count;
+        }
+
+        /// <summary>
+        /// Force the list to compact its backing data structure for optimal enumeration performance.
+        /// This operation takes O(n) time, where n the number of items in the list,
+        /// assuming frequent enumeration or forced compaction.
+        /// </summary>
+        public void ForceCompact()
+        {
+            this.compact();
+        }
+
+        /// <summary>
+        /// Force the list to compact its backing data structure for optimal enumeration performance.
+        /// It further trims it to use minimal memory.
+        /// This operation takes O(n) time, where n the number of items in the list,
+        /// assuming frequent enumeration or forced compaction.
+        /// </summary>
+        public void TrimExcess()
+        {
+            this.compact();
+            this.list.TrimExcess();
+        }
+
+        #endregion
+
+        #endregion
+
+    }
+}

--- a/src/Collections/DeletableObjectList.cs
+++ b/src/Collections/DeletableObjectList.cs
@@ -1,4 +1,4 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 
 namespace Bearded.Utilities.Collections
 {
@@ -28,6 +28,12 @@ namespace Bearded.Utilities.Collections
         /// </summary>
         public float MaxEmptyFraction { get; set; }
 
+
+        /// <summary>
+        /// Gets an approximation of the number of items in the list.
+        /// The value is an inclusive upper bound to the actual number of items.
+        /// </summary>
+        public int ApproximateCount { get { return this.count; } }
 
         #endregion
 
@@ -79,6 +85,18 @@ namespace Bearded.Utilities.Collections
         {
             this.list[i] = null;
             this.count--;
+
+            if(this.count == 0)
+                this.list.Clear();
+        }
+
+        /// <summary>
+        /// Clears the list of all items.
+        /// </summary>
+        public void Clear()
+        {
+            this.list.Clear();
+            this.count = 0;
         }
 
         #region Enumeration

--- a/src/Collections/DeletableObjectListEnumerator.cs
+++ b/src/Collections/DeletableObjectListEnumerator.cs
@@ -39,6 +39,7 @@ namespace Bearded.Utilities.Collections
                     else
                     {
                         this.Current = item;
+                        this.i++;
                         return true;
                     }
                 this.i++;

--- a/src/Collections/DeletableObjectListEnumerator.cs
+++ b/src/Collections/DeletableObjectListEnumerator.cs
@@ -1,0 +1,61 @@
+using System.Collections.Generic;
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// Enumerator for deletable object list.
+    /// Kept internal to hide implementation.
+    /// </summary>
+    internal class DeletableObjectListEnumerator<T> : IEnumerator<T>
+        where T : class, IDeletable
+    {
+        private readonly DeletableObjectList<T> deletableObjectList;
+        private readonly List<T> list;
+        private int i;
+
+        public DeletableObjectListEnumerator(DeletableObjectList<T> deletableObjectList, List<T> list)
+        {
+            this.deletableObjectList = deletableObjectList;
+            this.list = list;
+
+            deletableObjectList.RegisterEnumerator();
+        }
+
+        public void Dispose()
+        {
+            this.deletableObjectList.UnregisterEnumerator();
+        }
+
+        public bool MoveNext()
+        {
+            while (this.list.Count > this.i)
+            {
+                var item = this.list[this.i];
+                if (item != null)
+                    if (item.Deleted)
+                    {
+                        this.deletableObjectList.ClearBackingArrayIndex(this.i);
+                    }
+                    else
+                    {
+                        this.Current = item;
+                        return true;
+                    }
+                this.i++;
+            }
+            return false;
+        }
+
+        public void Reset()
+        {
+            this.i = 0;
+        }
+
+        public T Current { get; private set; }
+
+        object System.Collections.IEnumerator.Current
+        {
+            get { return this.Current; }
+        }
+    }
+}

--- a/src/Collections/IDeletable.cs
+++ b/src/Collections/IDeletable.cs
@@ -1,0 +1,14 @@
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// An interface for objects that can be deleted, used for automatic deletion from DeletableObjectList.
+    /// </summary>
+    public interface IDeletable
+    {
+        /// <summary>
+        /// Whether the object was deleted. This will cause it to be removed from all deletable object lists it is contained in.
+        /// Once this returns true, it should never return false afterwards. Otherwise integrity of lists can not be guarnateed.
+        /// </summary>
+        bool Deleted { get; }
+    }
+}

--- a/src/Collections/MutableLinkedList.cs
+++ b/src/Collections/MutableLinkedList.cs
@@ -1,0 +1,229 @@
+﻿using System;
+using System.Collections.Generic;
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// A generic linked list that can be modified while it is being enumerated.
+    /// This list is not threadsafe.
+    /// </summary>
+    public sealed class MutableLinkedList<T> : IEnumerable<T>
+        where T : class
+    {
+        #region Fields and Properties
+
+        private readonly LinkedList<MutableLinkedListEnumerator<T>> enumerators =
+            new LinkedList<MutableLinkedListEnumerator<T>>();
+
+        /// <summary>
+        /// Gets the first node in the linked list. Null if empty.
+        /// </summary>
+        public MutableLinkedListNode<T> First { get; private set; }
+
+        /// <summary>
+        /// Gets the last node in the linked list. Null if empty.
+        /// </summary>
+        public MutableLinkedListNode<T> Last { get; private set; }
+
+        /// <summary>
+        /// Gets the number of elements in the list.
+        /// </summary>
+        public int Count { get; private set; }
+
+        #endregion
+
+        #region Constructor
+
+        /// <summary>
+        /// Instantiates a new instance.
+        /// </summary>
+        public MutableLinkedList()
+        {
+            this.Count = 0;
+        }
+
+        #endregion
+
+        #region Methods
+
+        #region Add()
+
+        /// <summary>
+        /// Adds an item to the linked list. The node used to store the item is returned.
+        /// </summary>
+        /// <param name="item">The item to add.</param>
+        public MutableLinkedListNode<T> Add(T item)
+        {
+            var node = MutableLinkedListNode.For(item);
+            this.Add(node);
+            return node;
+        }
+
+        /// <summary>
+        /// Adds a linked list node to this list.
+        /// If the node is already in another list, an exception is thrown.
+        /// </summary>
+        /// <param name="node">The node to add.</param>
+        public void Add(MutableLinkedListNode<T> node)
+        {
+            if (node.List != null)
+                throw new Exception("Node cannot be in a list when adding it to one.");
+
+            node.List = this;
+
+            if (this.Count == 0)
+            {
+                this.First = node;
+            }
+            else
+            {
+                node.Prev = this.Last;
+                this.Last.Next = node;
+            }
+
+            this.Last = node;
+
+            this.Count++;
+        }
+
+        #endregion
+
+        #region Remove()
+
+        /// <summary>
+        /// Tries to return the first occurrence of an item from the list.
+        /// Returns true if it found and removed the item or false if the item is not in the list.
+        /// </summary>
+        /// <remarks>This method takes O(n) time to complete and should not be used unless necessary.</remarks>
+        /// <param name="item">The item to remove.</param>
+        public bool Remove(T item)
+        {
+            var n = this.First;
+            while (n != null)
+            {
+                if (n.Value == item)
+                {
+                    this.Remove(n);
+                    return true;
+                }
+                n = n.Next;
+            }
+            return false;
+        }
+
+        /// <summary>
+        /// Removes the specified node from the list.
+        /// Throws an exception if the given node is not in the list.
+        /// </summary>
+        /// <param name="node">The node to remove.</param>
+        public void Remove(MutableLinkedListNode<T> node)
+        {
+            if (node.List == null)
+                throw new Exception("Node must be in list to be removed.");
+
+            foreach (MutableLinkedListEnumerator<T> e in this.enumerators)
+                e.OnObjectRemove(node);
+
+            if (node == this.Last)
+                this.Last = node.Prev;
+            if (node == this.First)
+                this.First = node.Next;
+
+            this.Count--;
+
+            if (node.Next != null)
+            {
+                node.Next.Prev = node.Prev;
+            }
+            if (node.Prev != null)
+            {
+                node.Prev.Next = node.Next;
+            }
+            node.Next = null;
+            node.Prev = null;
+            node.List = null;
+        }
+
+        #endregion
+
+        #region Insertion
+
+        /// <summary>
+        /// Adds a given linked list node before another one already in this list.
+        /// This will throw an exception if the node is already in another list, of if the node to add before is null, or not in this list.
+        /// </summary>
+        /// <param name="newNode">The node to add and insert.</param>
+        /// <param name="beforeThis">The node to insert before.</param>
+        public void AddBefore(MutableLinkedListNode<T> newNode, MutableLinkedListNode<T> beforeThis)
+        {
+            if (beforeThis.List != this)
+                throw new Exception("The object to insert before must be in the same list.");
+            this.Add(newNode);
+            this.InsertBefore(newNode, beforeThis);
+        }
+
+        /// <summary>
+        /// Inserts a node before another node in the list.
+        /// The given nodes must both be in the list, and the node to insert must be the last one in it.
+        /// Otherwise an exception is thrown.
+        /// </summary>
+        /// <param name="node">The node to insert.</param>
+        /// <param name="beforeThis">The node to insert before.</param>
+        public void InsertBefore(MutableLinkedListNode<T> node, MutableLinkedListNode<T> beforeThis)
+        {
+            if (node.List != this)
+                throw new Exception("Object must already be in list before inserting.");
+            if (beforeThis.List != this)
+                throw new Exception("The object to insert before must be in the same list.");
+            if (node != this.Last)
+                throw new Exception("Inserted object must be last object in list.");
+            if (node == beforeThis)
+                throw new Exception("Cannot insert object before itself.");
+
+            this.Last = node.Prev;
+            if (beforeThis == this.First)
+                this.First = node;
+
+            node.Prev.Next = null;
+            node.Prev = beforeThis.Prev;
+            beforeThis.Prev = node;
+            node.Next = beforeThis;
+
+            if (node.Prev != null)
+                node.Prev.Next = node;
+        }
+
+        #endregion
+
+        #region Enumerating
+
+        /// <summary>
+        /// Returns an enumerator that iterates through the collection.
+        /// </summary>
+        public IEnumerator<T> GetEnumerator()
+        {
+            var e = new MutableLinkedListEnumerator<T>(this);
+            this.enumerators.AddFirst(e);
+            e.SetNode(this.enumerators.First);
+            return e;
+        }
+
+        internal void ForgetEnumerator(LinkedListNode<MutableLinkedListEnumerator<T>> node)
+        {
+            this.enumerators.Remove(node);
+        }
+
+        /// <summary>
+        /// Returns an enumerator that iterates through a collection.
+        /// </summary>
+        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        {
+            return this.GetEnumerator();
+        }
+
+        #endregion
+
+        #endregion
+
+    }
+}

--- a/src/Collections/MutableLinkedList.cs
+++ b/src/Collections/MutableLinkedList.cs
@@ -1,10 +1,11 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 
 namespace Bearded.Utilities.Collections
 {
     /// <summary>
     /// A generic linked list that can be modified while it is being enumerated.
+    /// Unless otherwise specified, all operations on this list, including removal by node, run in constant time.
     /// This list is not threadsafe.
     /// </summary>
     public sealed class MutableLinkedList<T> : IEnumerable<T>
@@ -94,7 +95,7 @@ namespace Bearded.Utilities.Collections
         /// Tries to return the first occurrence of an item from the list.
         /// Returns true if it found and removed the item or false if the item is not in the list.
         /// </summary>
-        /// <remarks>This method takes O(n) time to complete and should not be used unless necessary.</remarks>
+        /// <remarks>This method takes O(Count) time and its use is discouraged.</remarks>
         /// <param name="item">The item to remove.</param>
         public bool Remove(T item)
         {

--- a/src/Collections/MutableLinkedListEnumerator.cs
+++ b/src/Collections/MutableLinkedListEnumerator.cs
@@ -1,0 +1,96 @@
+using System.Collections.Generic;
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// Enumerator for mutable linked lists.
+    /// Kept internal to hide implementation.
+    /// </summary>
+    internal sealed class MutableLinkedListEnumerator<T> : IEnumerator<T>
+        where T : class
+    {
+
+        private readonly MutableLinkedList<T> list;
+
+        private bool initialised;
+        private bool currentWasDeleted;
+        private bool done;
+
+        public MutableLinkedListEnumerator(MutableLinkedList<T> list)
+        {
+            this.list = list;
+        }
+
+        private LinkedListNode<MutableLinkedListEnumerator<T>> node;
+        public void SetNode(LinkedListNode<MutableLinkedListEnumerator<T>> node)
+        {
+            if (this.node == null)
+                this.node = node;
+        }
+
+        public T Current
+        {
+            get { return this.current.Value; }
+        }
+
+        private MutableLinkedListNode<T> current;
+
+        public void OnObjectRemove(MutableLinkedListNode<T> obj)
+        {
+            if (obj != this.current)
+                return;
+
+            this.currentWasDeleted = true;
+            this.current = obj.Next;
+            if (this.current == null)
+                this.done = true;
+        }
+
+        public void Dispose()
+        {
+            this.list.ForgetEnumerator(this.node);
+        }
+
+        public bool MoveNext()
+        {
+            if (this.done)
+                return false;
+            if (!this.initialised)
+            {
+                if (this.list.Count == 0)
+                    return false;
+                this.initialised = true;
+                this.current = this.list.First;
+            }
+            else
+            {
+                if (this.currentWasDeleted)
+                {
+                    this.currentWasDeleted = false;
+                    return true;
+                }
+                this.current = this.current.Next;
+                if (this.current == null)
+                {
+                    this.done = true;
+                    return false;
+                }
+            }
+            return true;
+        }
+
+        public void Reset()
+        {
+            this.current = null;
+            this.done = false;
+            this.initialised = false;
+            this.currentWasDeleted = false;
+        }
+
+        object System.Collections.IEnumerator.Current
+        {
+            get { return this.Current; }
+        }
+
+    }
+}

--- a/src/Collections/MutableLinkedListItem.cs
+++ b/src/Collections/MutableLinkedListItem.cs
@@ -1,0 +1,34 @@
+namespace Bearded.Utilities.Collections
+{
+
+    /// <summary>
+    /// This type can be used to have a class be both the value as well as the node in a linked list to prevent unneeded allocations.
+    /// Usage:
+    /// MyClass : MutableLinkedListItem&lt;MyClass&gt;
+    /// MutableLinkedList&lt;MyClass&gt;
+    /// Make sure you add this as node and not as item to the linked list to prevent creation of the node wrapper.
+    /// </summary>
+    /// <typeparam name="TMe">The type of the inheriting class.</typeparam>
+    abstract class MutableLinkedListItem<TMe> : MutableLinkedListNode<TMe>
+        where TMe : MutableLinkedListNode<TMe>
+    {
+
+    }
+
+    // ReSharper disable once UnusedTypeParameter
+    /// <summary>
+    /// This type can be used to have a class be both the value as well as the node in a linked list, mixed with actual nodes.
+    /// Usage:
+    /// MyClass : MutableLinkedListItem&lt;MyClass, MyInterface&gt;
+    /// MutableLinkedList&lt;MyInterface&gt;
+    /// Make sure you add this as node and not as item to the linked list to prevent creation of the node wrapper.
+    /// </summary>
+    /// <typeparam name="TMe">The type of the inheriting class.</typeparam>
+    /// <typeparam name="TInterface">The type of the lists interface.</typeparam>
+    abstract class MutableLinkedListItem<TMe, TInterface> : MutableLinkedListNode<TInterface>
+        where TInterface : class
+        where TMe : TInterface
+    {
+
+    }
+}

--- a/src/Collections/MutableLinkedListNode.cs
+++ b/src/Collections/MutableLinkedListNode.cs
@@ -1,0 +1,106 @@
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// Static class to initialise new mutable linked list nodes.
+    /// </summary>
+    public static class MutableLinkedListNode
+    {
+        /// <summary>
+        /// Returns a new mutable linked list node for the given value.
+        /// </summary>
+        public static MutableLinkedListNode<T> For<T>(T value)
+            where T : class
+        {
+            return new MutableLinkedListNode<T>(value);
+        }
+    }
+
+    /// <summary>
+    /// A node for mutable linked lists.
+    /// </summary>
+    public class MutableLinkedListNode<T>
+        where T : class
+    {
+
+        #region Fields and Properties
+
+        private readonly T value;
+
+        /// <summary>
+        /// The value stored in the node.
+        /// </summary>
+        public T Value { get { return this.value; } }
+
+        // Next, Prev and List are internally writeable to
+        // simplify addition, removal and insertion code.
+        // Do not mess with them!
+        internal MutableLinkedListNode<T> Next { get; set; }
+        internal MutableLinkedListNode<T> Prev { get; set; }
+
+        /// <summary>
+        /// The list the node is part of.
+        /// </summary>
+        public MutableLinkedList<T> List { get; internal set; }
+
+        internal bool ChangingList { get; private set; }
+
+        #endregion
+
+        #region Constructors
+        
+        internal MutableLinkedListNode(T value)
+        {
+            this.value = value;
+        }
+
+        internal MutableLinkedListNode()
+        {
+            this.value = this as T;
+        }
+
+        #endregion
+
+        #region Methods
+
+        /// <summary>
+        /// Adds this node to a given list.
+        /// </summary>
+        /// <param name="list">The list to add the node to.</param>
+        public void AddToList(MutableLinkedList<T> list)
+        {
+            list.Add(this);
+        }
+
+        /// <summary>
+        /// Adds this node to a given list before another node.
+        /// </summary>
+        /// <param name="list">The list to add the node to.</param>
+        /// <param name="beforeThis">The node to add this before.</param>
+        public void AddToListBefore(MutableLinkedList<T> list, MutableLinkedListNode<T> beforeThis)
+        {
+            list.AddBefore(this, beforeThis);
+        }
+
+        /// <summary>
+        /// Insert this node before another on.
+        /// Both nodes must be in the same list, and this node must be the last on in the list.
+        /// </summary>
+        /// <param name="beforeThis">The node to add this before.</param>
+        public void InsertBefore(MutableLinkedListNode<T> beforeThis)
+        {
+            this.List.InsertBefore(this, beforeThis);
+        }
+
+        /// <summary>
+        /// Removes this node from the list it is in.
+        /// </summary>
+        public void RemoveFromList()
+        {
+            this.List.Remove(this);
+        }
+
+        #endregion
+
+    }
+}


### PR DESCRIPTION
Code is complete and has been tested in conjunction with http://genericgamedev.com/general/on-collections/

Note that I kept the [MutableLinkedListItem](https://github.com/amulware/utilities/blob/d9c6ca641b8f90ffe78d4a813ddf1ac1190c6ffc/src/Collections/MutableLinkedListItem.cs) private for now.
It works just fine, but its complicated generic signature might be confusing, and it is not strictly speaking necessary.

Also, calling MutableLinkedList.Add(/* a mutable linked list item*/) results in an ambiguous call, that the compiler cannot resolve (Visual Studio shows the error as well), so that an explicit cast is necessary.

Maybe I should add an .AsNode property to the MutableLinkedListItem (casting it down to a node)?
And possibly also an .AsInterface (better name?) property to the same class with two type parameters.

Either way, these things are open to discussion, but I suggest merging this as is for now, and figuring out these details after.