### PR TITLE
Added travis configuration file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,2 @@
+language: csharp
+solution: Bearded.Utilities.sln


### PR DESCRIPTION
The travis configuration file allows for integrating the [Travis CI](https://travis-ci.org/) build service with this repository. (Note that right now builds fail due to the use of an unsupported test framework, see #33.)