### PR TITLE
XUnit for Xamarin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -181,3 +181,8 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
+
+# Xunit Nuget packages through Xamarin
+tests/xunit.*
+
+*.userprefs

--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,7 @@
 *.suo
 *.user
 *.sln.docstates
+*.userprefs
 
 # Build results
 [Dd]ebug/
@@ -181,8 +182,3 @@ UpgradeLog*.htm
 
 # Microsoft Fakes
 FakesAssemblies/
-
-# Xunit Nuget packages through Xamarin
-tests/xunit.*
-
-*.userprefs

--- a/src/Bearded.Utilities.csproj
+++ b/src/Bearded.Utilities.csproj
@@ -48,16 +48,12 @@
     <WarningLevel>4</WarningLevel>
     <DocumentationFile>..\bin\Debug\Bearded.Utilities.xml</DocumentationFile>
   </PropertyGroup>
-  <PropertyGroup>
-    <StartupObject />
-  </PropertyGroup>
   <ItemGroup>
-    <Reference Include="OpenTK, Version=1.1.0.0, Culture=neutral, PublicKeyToken=bad199fe84eb3df4, processorArchitecture=MSIL">
-      <SpecificVersion>False</SpecificVersion>
-      <HintPath>..\libs\OpenTK.dll</HintPath>
-    </Reference>
     <Reference Include="System" />
     <Reference Include="System.Drawing" />
+    <Reference Include="OpenTK">
+      <HintPath>..\libs\OpenTK.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Data\" />

--- a/tests/Bearded.Utilities.Tests.csproj
+++ b/tests/Bearded.Utilities.Tests.csproj
@@ -11,7 +11,6 @@
     <AssemblyName>Bearded.Utilities.Tests</AssemblyName>
     <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
-    <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
     <VSToolsPath Condition="'$(VSToolsPath)' == ''">$(MSBuildExtensionsPath32)\Microsoft\VisualStudio\v$(VisualStudioVersion)</VSToolsPath>
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
@@ -40,9 +39,7 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
-    <Reference Include="System.Core">
-      <RequiredTargetFramework>3.5</RequiredTargetFramework>
-    </Reference>
+    <Reference Include="System.Core" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
       <Private>True</Private>
@@ -73,7 +70,7 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\src\Bearded.Utilities.csproj">
-      <Project>{2f580b9d-6255-4427-8395-5ef236c9401c}</Project>
+      <Project>{2F580B9D-6255-4427-8395-5EF236C9401C}</Project>
       <Name>Bearded.Utilities</Name>
     </ProjectReference>
   </ItemGroup>

--- a/tests/Bearded.Utilities.Tests.csproj
+++ b/tests/Bearded.Utilities.Tests.csproj
@@ -27,6 +27,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <Prefer32Bit>false</Prefer32Bit>
+    <CustomCommands>
+      <CustomCommands>
+        <Command type="Execute" command="mono ${SolutionDir}/packages/xunit.runner.console.2.0.0/tools/xunit.console.exe" workingdir="${SolutionDir}" />
+        <Command type="Custom" name="Run tests" command="mono packages/xunit.runner.console.2.0.0/tools/xunit.console.exe tests/bin/${ProjectConfigName}/Bearded.Utilities.Tests.dll" workingdir="${SolutionDir}" />
+      </CustomCommands>
+    </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -40,17 +46,14 @@
   <ItemGroup>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.abstractions.2.0.0\lib\net35\xunit.abstractions.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.assert, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.assert.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.assert.dll</HintPath>
-      <Private>True</Private>
     </Reference>
-    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
+    <Reference Include="xunit.core, Version=2.0.0.2929, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c">
       <HintPath>..\packages\xunit.extensibility.core.2.0.0\lib\portable-net45+win+wpa81+wp80+monotouch+monoandroid+Xamarin.iOS\xunit.core.dll</HintPath>
-      <Private>True</Private>
     </Reference>
   </ItemGroup>
   <Choose>

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -5,4 +5,5 @@
   <package id="xunit.assert" version="2.0.0" targetFramework="net45" />
   <package id="xunit.core" version="2.0.0" targetFramework="net45" />
   <package id="xunit.extensibility.core" version="2.0.0" targetFramework="net45" />
+  <package id="xunit.runner.console" version="2.0.0" targetFramework="net45" />
 </packages>


### PR DESCRIPTION
Made some small changes in references and project files to make the project fully compatible with Xamarin Studio. XUnit tests can't be run from the console yet due to the same bug that prevents us from running unit tests in Travis.