### PR TITLE
removed space estimate from prefix trie dictionary allocation, closes #52

### DIFF
--- a/src/Collections/PrefixTrie.cs
+++ b/src/Collections/PrefixTrie.cs
@@ -47,7 +47,7 @@ namespace Bearded.Utilities.Collections
                 if (iMin >= iMax)
                     return null;
 
-                var dict = new Dictionary<char, Node>(iMax - iMin);
+                var dict = new Dictionary<char, Node>();
 
                 int index2 = index + 1;
 


### PR DESCRIPTION
Alternative solution would enumerate input collection to determine number of children. A performance test could be done to see if this is faster than the reallocations of the current approach.