### PR TITLE
Replace static with instanced ids

### DIFF
--- a/src/Bearded.Utilities.csproj
+++ b/src/Bearded.Utilities.csproj
@@ -91,6 +91,7 @@
     <Compile Include="Algorithms\HungarianAlgorithm.cs" />
     <Compile Include="Algorithms\BinPacking.cs" />
     <Compile Include="Collections\PrefixTrie.cs" />
+    <Compile Include="Core\IdManager.cs" />
     <Compile Include="Core\Logger.cs" />
     <Compile Include="Core\StaticRandom.cs" />
     <Compile Include="Core\RandomExtensions.cs" />

--- a/src/Core/Id.cs
+++ b/src/Core/Id.cs
@@ -4,21 +4,6 @@ using System.Runtime.InteropServices;
 namespace Bearded.Utilities
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public struct Id
-    {
-        private readonly int value;
-
-        public int Value => value;
-
-        public Id(int value)
-        {
-            this.value = value;
-        }
-
-        public Id<T> Generic<T>() => new Id<T>(value);
-    }
-
-    [StructLayout(LayoutKind.Sequential, Pack = 1)]
     public struct Id<T> : IEquatable<Id<T>>
     {
         private readonly int value;
@@ -29,8 +14,6 @@ namespace Bearded.Utilities
         {
             this.value = value;
         }
-
-        public Id Simple => new Id(value);
 
         public bool IsValid => value != 0;
         public static Id<T> Invalid => new Id<T>(0);

--- a/src/Core/Id.cs
+++ b/src/Core/Id.cs
@@ -1,80 +1,44 @@
 ﻿using System;
-using System.Threading;
+using System.Runtime.InteropServices;
 
 namespace Bearded.Utilities
 {
-    /// <summary>
-    /// Represents a type safe ID for a given type.
-    /// Uses a 32 bit integer and thus only guarantees uint.MaxValue unique IDs.
-    /// </summary>
-    public struct Id<T> : IEquatable<Id<T>>
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Id
     {
-// ReSharper disable once StaticFieldInGenericType
-        private static int counter;
-
-        /// <summary>
-        /// Returns a new id.
-        /// This call is not thread safe. Never use this together with NextThreadSafe().
-        /// </summary>
-        public static Id<T> Next()
-        {
-            return new Id<T>(++counter);
-        }
-
-        /// <summary>
-        /// Returns a new id.
-        /// This call is thread safe. Never use this together with Next().
-        /// </summary>
-        public static Id<T> NextThreadSafe()
-        {
-            return new Id<T>(Interlocked.Increment(ref counter));
-        }
-
         private readonly int value;
 
-        private Id(int value)
+        public int Value => value;
+
+        public Id(int value)
         {
             this.value = value;
         }
 
-        /// <summary>
-        /// Returns the hash code for this instance.
-        /// </summary>
-        public override int GetHashCode()
+        public Id<T> Generic<T>() => new Id<T>(value);
+    }
+
+    [StructLayout(LayoutKind.Sequential, Pack = 1)]
+    public struct Id<T> : IEquatable<Id<T>>
+    {
+        private readonly int value;
+
+        public int Value => value;
+
+        public Id(int value)
         {
-            return this.value.GetHashCode();
+            this.value = value;
         }
 
-        /// <summary>
-        /// Indicates whether the current object is equal to another object of the same type.
-        /// </summary>
-        public bool Equals(Id<T> other)
-        {
-            return this.value.Equals(other.value);
-        }
+        public Id Simple => new Id(value);
 
-        /// <summary>
-        /// Indicates whether this instance and a specified object are equal.
-        /// </summary>
-        public override bool Equals(object obj)
-        {
-            return obj is Id<T> && this.Equals((Id<T>)obj);
-        }
+        public bool IsValid => value != 0;
+        public static Id<T> Invalid => new Id<T>(0);
 
-        /// <summary>
-        /// Compares two IDs for equality.
-        /// </summary>
-        public static bool operator ==(Id<T> id0, Id<T> id1)
-        {
-            return id0.Equals(id1);
-        }
-
-        /// <summary>
-        /// Compares two IDs for inequality.
-        /// </summary>
-        public static bool operator !=(Id<T> id0, Id<T> id1)
-        {
-            return !(id0 == id1);
-        }
+        public override int GetHashCode() => value.GetHashCode();
+        public bool Equals(Id<T> other) => value.Equals(other.value);
+        public override bool Equals(object obj) => obj is Id<T> && Equals((Id<T>)obj);
+        public static bool operator ==(Id<T> left, Id<T> right) => left.Equals(right);
+        public static bool operator !=(Id<T> left, Id<T> right) => !(left == right);
     }
 }

--- a/src/Core/IdManager.cs
+++ b/src/Core/IdManager.cs
@@ -1,0 +1,19 @@
+﻿using System;
+using System.Collections.Generic;
+using Bearded.Utilities.Linq;
+
+namespace Bearded.Utilities
+{
+    public sealed class IdManager
+    {
+        private readonly Dictionary<Type, int> lastIds = new Dictionary<Type, int>();
+
+        public Id<T> GetNext<T>()
+        {
+            var type = typeof(T);
+            var i = lastIds.ValueOrDefault(type) + 1;
+            lastIds[type] = i;
+            return new Id<T>(i);
+        }
+    }
+}

--- a/src/Linq/Extensions.cs
+++ b/src/Linq/Extensions.cs
@@ -180,7 +180,8 @@ namespace Bearded.Utilities.Linq
 
         public static TValue ValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
         {
-            dict.TryGetValue(key, out var value);
+            TValue value;
+            dict.TryGetValue(key, out value);
             return value;
         }
 

--- a/src/Linq/Extensions.cs
+++ b/src/Linq/Extensions.cs
@@ -180,8 +180,7 @@ namespace Bearded.Utilities.Linq
 
         public static TValue ValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
         {
-            TValue value;
-            dict.TryGetValue(key, out value);
+            dict.TryGetValue(key, out var value);
             return value;
         }
 

--- a/src/Linq/Extensions.cs
+++ b/src/Linq/Extensions.cs
@@ -178,6 +178,12 @@ namespace Bearded.Utilities.Linq
             }
         }
 
+        public static TValue ValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
+        {
+            dict.TryGetValue(key, out var value);
+            return value;
+        }
+
         #endregion
 
         #region Random


### PR DESCRIPTION
Statics are bad and unusable. We don't have the thread safe incrementer anymore, but I don't think that was really all that useful in the first place for what this is used for.

If we merge this, we can replace both the ids and the linq extension included in TD.