### PR TITLE
Add IIdable and IdDictionary

### DIFF
--- a/src/Bearded.Utilities.csproj
+++ b/src/Bearded.Utilities.csproj
@@ -90,6 +90,8 @@
   <ItemGroup>
     <Compile Include="Algorithms\HungarianAlgorithm.cs" />
     <Compile Include="Algorithms\BinPacking.cs" />
+    <Compile Include="Collections\IdDictionary.cs" />
+    <Compile Include="Collections\IIdable.cs" />
     <Compile Include="Collections\PrefixTrie.cs" />
     <Compile Include="Core\IdManager.cs" />
     <Compile Include="Core\Logger.cs" />

--- a/src/Collections/IIdable.cs
+++ b/src/Collections/IIdable.cs
@@ -1,0 +1,8 @@
+﻿
+namespace Bearded.Utilities.Collections
+{
+    public interface IIdable<T>
+    {
+        Id<T> Id { get; }
+    }
+}

--- a/src/Collections/IdDictionary.cs
+++ b/src/Collections/IdDictionary.cs
@@ -1,0 +1,12 @@
+﻿using System.Collections.Generic;
+
+namespace Bearded.Utilities.Collections
+{
+    public class IdDictionary<T> : Dictionary<Id<T>, T>
+        where T : IIdable<T>
+    {
+        public void Add(T item) => Add(item.Id, item);
+
+        public void Remove(T item) => Remove(item.Id);
+    }
+}


### PR DESCRIPTION
Wanted to add a `Contains(T)` method to the dictionary, but was not sure if it should check only the id, or also get the value and call `Equals()`.

Squash if you have an id.