### PR TITLE
Fixed list resizing in logger entry copying

### DIFF
--- a/src/Core/Logger.cs
+++ b/src/Core/Logger.cs
@@ -240,7 +240,7 @@ namespace Bearded.Utilities
             lock (lines)
             {
                 if (collection is List<Entry> list)
-                    list.Capacity = list.Count + lines.Count;
+                    ensureListCapacity(list, list.Count + lines.Count);
 
                 foreach (var entry in lines)
                     collection.Add(entry);
@@ -254,12 +254,18 @@ namespace Bearded.Utilities
         {
             lock (lines)
             {
-                if (collection is List<Entry> list)
-                    list.Capacity = list.Count + lines.Count;
+                if (severity == Severity.Trace && collection is List<Entry> list)
+                    ensureListCapacity(list, list.Count + lines.Count);
 
                 foreach (var entry in lines.Where(entry => entry.Severity <= severity))
                     collection.Add(entry);
             }
+        }
+
+        private static void ensureListCapacity(List<Entry> list, int neededCapacity)
+        {
+            if (list.Capacity < neededCapacity)
+                list.Capacity = Max(list.Capacity * 2, neededCapacity);
         }
 
         /// <summary>


### PR DESCRIPTION
I made sure we are doubling the size correctly, and not allocating new arrays for each new added entry.

Also, I think it should only do this in the filtered case, if the severity given is TRACE (I.e. there is no filter).

Should we go as far as to call the first method if it is TRACE? What if someone has just makes up their own severity (by casting integers to severity values)? Not sure how this should be best.