### PR TITLE
Make MutableLinkedListItem public

### DIFF
--- a/src/Collections/MutableLinkedListItem.cs
+++ b/src/Collections/MutableLinkedListItem.cs
@@ -9,25 +9,8 @@ namespace Bearded.Utilities.Collections
     /// Make sure you add this as node and not as item to the linked list to prevent creation of the node wrapper.
     /// </summary>
     /// <typeparam name="TMe">The type of the inheriting class.</typeparam>
-    abstract class MutableLinkedListItem<TMe> : MutableLinkedListNode<TMe>
+    public abstract class MutableLinkedListItem<TMe> : MutableLinkedListNode<TMe>
         where TMe : MutableLinkedListNode<TMe>
-    {
-
-    }
-
-    // ReSharper disable once UnusedTypeParameter
-    /// <summary>
-    /// This type can be used to have a class be both the value as well as the node in a linked list, mixed with actual nodes.
-    /// Usage:
-    /// MyClass : MutableLinkedListItem&lt;MyClass, MyInterface&gt;
-    /// MutableLinkedList&lt;MyInterface&gt;
-    /// Make sure you add this as node and not as item to the linked list to prevent creation of the node wrapper.
-    /// </summary>
-    /// <typeparam name="TMe">The type of the inheriting class.</typeparam>
-    /// <typeparam name="TInterface">The type of the lists interface.</typeparam>
-    abstract class MutableLinkedListItem<TMe, TInterface> : MutableLinkedListNode<TInterface>
-        where TInterface : class
-        where TMe : TInterface
     {
 
     }


### PR DESCRIPTION
Not sure if I like this collection at all anymore, but while we have it, might as well make this relatively useful type public.