### PR TITLE
Add random extension tests

### DIFF
--- a/tests/Bearded.Utilities.Tests.csproj
+++ b/tests/Bearded.Utilities.Tests.csproj
@@ -94,6 +94,7 @@
     <Compile Include="Algorithms\BinPackingTests.cs" />
     <Compile Include="Collections\PriorityQueueTests.cs" />
     <Compile Include="Collections\StaticPriorityQueueTests.cs" />
+    <Compile Include="Core\RandomExtensionTests.cs" />
     <Compile Include="Generators\FloatGenerators.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Tilemaps\RectangularTilemapTests.cs" />

--- a/tests/Core/RandomExtensionTests.cs
+++ b/tests/Core/RandomExtensionTests.cs
@@ -1,0 +1,147 @@
+﻿using System;
+using FsCheck.Xunit;
+using Xunit;
+
+namespace Bearded.Utilities.Tests.Core
+{
+    public class RandomExtensionTests
+    {
+        [Property]
+        public void NextLong(int seed)
+        {
+            var random = new Random(seed);
+
+            random.NextLong();
+        }
+
+        [Property]
+        public void NextLongWithMax(int seed, long max)
+        {
+            var random = new Random(seed);
+
+            var number = random.NextLong(max);
+            
+            Assert.InRange(number, 0, max - 1);
+        }
+
+        [Property]
+        public void NextLongWithMinAndMax(int seed, long min, long max)
+        {
+            var random = new Random(seed);
+
+            var number = random.NextLong(min, max);
+
+            Assert.InRange(number, min, max - 1);
+        }
+
+        [Property]
+        public void NextDoubleWithMax(int seed, double max)
+        {
+            var random = new Random(seed);
+
+            var number = random.NextDouble(max);
+
+            Assert.InRange(number, 0, max);
+            Assert.NotEqual(max, number);
+        }
+
+        [Property]
+        public void NextDoubleWithMinAndMax(int seed, double min, double max)
+        {
+            var random = new Random(seed);
+
+            var number = random.NextDouble(min, max);
+
+            Assert.InRange(number, 0, max);
+            Assert.NotEqual(max, number);
+        }
+
+        [Property]
+        public void NextFloat(int seed)
+        {
+            var random = new Random(seed);
+
+            random.NextFloat();
+        }
+
+        [Property]
+        public void NextFloatWithMax(int seed, float max)
+        {
+            var random = new Random(seed);
+
+            var number = random.NextFloat(max);
+
+            Assert.InRange(number, 0, max);
+            Assert.NotEqual(max, number);
+        }
+
+        [Property]
+        public void NextFloatWithMinAndMax(int seed, float min, float max)
+        {
+            var random = new Random(seed);
+
+            var number = random.NextFloat(min, max);
+
+            Assert.InRange(number, 0, max);
+            Assert.NotEqual(max, number);
+        }
+
+        [Property]
+        public void NextSign(int seed)
+        {
+            var random = new Random(seed);
+
+            var sign = random.NextSign();
+
+            Assert.Equal(1, Math.Abs(sign));
+        }
+
+        [Property]
+        public void NextBool(int seed)
+        {
+            var random = new Random(seed);
+
+            random.NextBool();
+        }
+
+        [Property]
+        public void NextBoolWithPropabilityZero(int seed)
+        {
+            var random = new Random(seed);
+
+            var b = random.NextBool(0);
+            
+            Assert.Equal(false, b);
+        }
+
+        [Property]
+        public void NextBoolWithPropabilityOne(int seed)
+        {
+            var random = new Random(seed);
+
+            var b = random.NextBool(1);
+
+            Assert.Equal(true, b);
+        }
+
+        [Property]
+        public void DiscretiseWithArbitraryValue(int seed, float value)
+        {
+            var random = new Random(seed);
+
+            var number = random.Discretise(value);
+            
+            Assert.InRange(number, (int)value, (int)value + 1);
+        }
+
+        [Property]
+        public void DiscretiseWithRoundValue(int seed, int value)
+        {
+            var random = new Random(seed);
+
+            var number = random.Discretise(value);
+
+            Assert.Equal(value, number);
+        }
+    }
+}


### PR DESCRIPTION
See #88.

Currently, several tests fail, mostly because we have not really defined the behaviour of our NextLong and NextDouble methods.

I propose we use the same behaviour as System.Random.Next (returning integers):

- NextX(max) throws if max is negative, returns 0 if max is 0, and otherwise samples from [0, max[, 
- NextX(min, max) throws if max is less than min, returns min if min is max, and otherwise samples from [min, max[, 

I don't really _like_ this behaviour, especially for the max==0/min==max, but I suppose this would be the most consistent with existing behaviours?

I'm also not sure how to test the normally distributed methods. Should I just call them all to make sure they don't crash? Maybe check that they don't return NaN/+-infinity?