### PR TITLE
:sparkles: Add DirectedAcyclicGraph class

### DIFF
--- a/src/Bearded.Utilities.csproj
+++ b/src/Bearded.Utilities.csproj
@@ -57,6 +57,9 @@
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
+    <Reference Include="System.Collections.Immutable, Version=1.2.3.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.Collections.Immutable.1.5.0\lib\netstandard2.0\System.Collections.Immutable.dll</HintPath>
+    </Reference>
     <Reference Include="System.Drawing" />
     <Reference Include="OpenTK">
       <HintPath>$(SolutionDir)\packages\OpenTK.2.0.0\lib\net20\OpenTK.dll</HintPath>
@@ -95,6 +98,8 @@
   <ItemGroup>
     <Compile Include="Algorithms\HungarianAlgorithm.cs" />
     <Compile Include="Algorithms\BinPacking.cs" />
+    <Compile Include="Collections\DirectedAcyclicGraph.cs" />
+    <Compile Include="Collections\DirectedAcyclicGraphTransitiveReducer.cs" />
     <Compile Include="Collections\IdDictionary.cs" />
     <Compile Include="Collections\IIdable.cs" />
     <Compile Include="Collections\PrefixTrie.cs" />

--- a/src/Collections/DirectedAcyclicGraph.cs
+++ b/src/Collections/DirectedAcyclicGraph.cs
@@ -1,0 +1,138 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Collections.Immutable;
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// Data structure for storing directed acyclic graphs (DAGs).
+    ///
+    /// <para>Note that no validation is in place to verify there are no cycles.</para>
+    /// </summary>
+    public sealed class DirectedAcyclicGraph<T> where T : IEquatable<T>
+    {
+        private readonly HashSet<T> elements = new HashSet<T>();
+        private readonly HashSet<T> roots = new HashSet<T>();
+        private readonly Dictionary<T, HashSet<T>> outgoingEdges = new Dictionary<T, HashSet<T>>();
+        private readonly Dictionary<T, HashSet<T>> incomingEdges = new Dictionary<T, HashSet<T>>();
+
+        public IReadOnlyCollection<T> Elements => ImmutableHashSet.CreateRange(elements);
+
+        public int Count => elements.Count;
+
+        public void AddElement(T element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            if (!elements.Add(element))
+            {
+                return;
+            }
+            roots.Add(element);
+            outgoingEdges.Add(element, new HashSet<T>());
+            incomingEdges.Add(element, new HashSet<T>());
+        }
+
+        public void AddEdge(T from, T to)
+        {
+            if (from == null) throw new ArgumentNullException(nameof(from));
+            if (to == null) throw new ArgumentNullException(nameof(to));
+            if (!elements.Contains(from)) throw new ArgumentException("Element not in graph.", nameof(from));
+            if (!elements.Contains(to)) throw new ArgumentException("Element not in graph.", nameof(to));
+            if (from.Equals(to))
+            {
+                throw new InvalidOperationException("Cannot make self-edges in directed acyclic graph.");
+            }
+
+            outgoingEdges[from].Add(to);
+            incomingEdges[to].Add(from);
+
+            if (roots.Contains(to))
+            {
+                roots.Remove(to);
+            }
+        }
+
+        public bool RemoveElement(T element)
+        {
+            if (element == null) throw new ArgumentNullException(nameof(element));
+
+            if (!elements.Remove(element))
+            {
+                return false;
+            }
+            roots.Remove(element);
+
+            foreach (var to in outgoingEdges[element])
+            {
+                incomingEdges[to].Remove(element);
+                if (incomingEdges[to].Count == 0)
+                {
+                    roots.Add(to);
+                }
+            }
+            foreach (var from in incomingEdges[element])
+            {
+                outgoingEdges[from].Remove(element);
+            }
+
+            return true;
+        }
+
+        public bool RemoveEdge(T from, T to)
+        {
+            if (from == null) throw new ArgumentNullException(nameof(from));
+            if (to == null) throw new ArgumentNullException(nameof(to));
+            if (!elements.Contains(from)) throw new ArgumentException("Element not in graph.", nameof(from));
+            if (!elements.Contains(to)) throw new ArgumentException("Element not in graph.", nameof(to));
+
+            if (!outgoingEdges[from].Remove(to))
+            {
+                return false;
+            }
+
+            incomingEdges[to].Remove(from);
+            if (incomingEdges[to].Count == 0)
+            {
+                roots.Add(to);
+            }
+
+            return true;
+        }
+
+        public IReadOnlyCollection<T> GetOutgoingEdgesFor(T element)
+        {
+            if (!elements.Contains(element))
+            {
+                throw new ArgumentException("Element does not exist in this graph.", nameof(element));
+            }
+
+            return ImmutableHashSet.CreateRange(outgoingEdges[element]);
+        }
+        
+        public IReadOnlyCollection<T> GetIncomingEdgesFor(T element)
+        {
+            if (!elements.Contains(element))
+            {
+                throw new ArgumentException("Element does not exist in this graph.", nameof(element));
+            }
+
+            return ImmutableHashSet.CreateRange(incomingEdges[element]);
+        }
+
+        /// <summary>
+        /// Returns the transitive reduction of this graph. That is, this method returns the sub-graph with a minimal
+        /// number of edges such that if there exists a path from A to B in this graph, there will be one in the
+        /// sub-graph.
+        ///
+        /// <para>
+        /// Specifically, if there is an edge (A, B) and there exists a different path A -> ... -> B, the edge will be
+        /// removed.
+        /// </para>
+        /// </summary>
+        public DirectedAcyclicGraph<T> GetTransitiveReduction()
+        {
+            return DirectedAcyclicGraphTransitiveReducer<T>.ReduceGraph(this);
+        }
+    }
+}

--- a/src/Collections/DirectedAcyclicGraphTransitiveReducer.cs
+++ b/src/Collections/DirectedAcyclicGraphTransitiveReducer.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace Bearded.Utilities.Collections
+{
+    static class DirectedAcyclicGraphTransitiveReducer<T> where T : IEquatable<T>
+    {
+        public static DirectedAcyclicGraph<T> ReduceGraph(DirectedAcyclicGraph<T> graph)
+        {
+            // Prevent making collections more than once.
+            var elements = graph.Elements;
+            var outgoingEdges = elements.ToDictionary(e => e, graph.GetOutgoingEdgesFor);
+            
+            var reducedGraph = new DirectedAcyclicGraph<T>();
+
+            foreach (var element in elements)
+            {
+                reducedGraph.AddElement(element);
+            }
+
+            foreach (var element in elements)
+            {
+                // Remove all outgoing edges that are reachable from element but not direct children.
+                var children = outgoingEdges[element];
+                var reducedEdges = new HashSet<T>(outgoingEdges[element]);
+                foreach (var child in children)
+                {
+                    foreach (var descendant in traverseRecursively(outgoingEdges, child))
+                    {
+                        if (descendant.Equals(child)) continue;
+                        reducedEdges.Remove(descendant);
+                    }
+                }
+
+                foreach (var neighbor in reducedEdges)
+                {
+                    reducedGraph.AddEdge(element, neighbor);
+                }
+            }
+
+            return reducedGraph;
+        }
+
+        private static IEnumerable<T> traverseRecursively(IReadOnlyDictionary<T, IReadOnlyCollection<T>> outgoingEdges, T start)
+        {
+            yield return start;
+            foreach (var neighbor in outgoingEdges[start])
+            foreach (var descendant in traverseRecursively(outgoingEdges, neighbor))
+                yield return descendant;
+        }
+    }
+}

--- a/src/packages.config
+++ b/src/packages.config
@@ -2,5 +2,6 @@
 <packages>
   <package id="OpenTK" version="2.0.0" targetFramework="net45" />
   <package id="StyleCop.Analyzers" version="1.0.2" targetFramework="net462" developmentDependency="true" />
+  <package id="System.Collections.Immutable" version="1.5.0" targetFramework="net462" />
   <package id="System.ValueTuple" version="4.3.0" targetFramework="net45" />
 </packages>

--- a/tests/Bearded.Utilities.Tests.csproj
+++ b/tests/Bearded.Utilities.Tests.csproj
@@ -48,6 +48,9 @@
     <Prefer32Bit>false</Prefer32Bit>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="FluentAssertions, Version=5.4.2.0, Culture=neutral, PublicKeyToken=33f2691a05b67b6a, processorArchitecture=MSIL">
+      <HintPath>..\packages\FluentAssertions.5.4.2\lib\net45\FluentAssertions.dll</HintPath>
+    </Reference>
     <Reference Include="FsCheck, Version=2.9.0.0, Culture=neutral, processorArchitecture=MSIL">
       <HintPath>..\packages\FsCheck.2.9.0\lib\net452\FsCheck.dll</HintPath>
     </Reference>
@@ -62,9 +65,11 @@
     </Reference>
     <Reference Include="System" />
     <Reference Include="System.Core" />
-    <Reference Include="System.ValueTuple, Version=4.0.1.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
-      <HintPath>..\packages\System.ValueTuple.4.3.0\lib\netstandard1.0\System.ValueTuple.dll</HintPath>
+    <Reference Include="System.ValueTuple, Version=4.0.2.0, Culture=neutral, PublicKeyToken=cc7b13ffcd2ddd51, processorArchitecture=MSIL">
+      <HintPath>..\packages\System.ValueTuple.4.4.0\lib\net461\System.ValueTuple.dll</HintPath>
     </Reference>
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Xml.Linq" />
     <Reference Include="xunit.abstractions, Version=2.0.0.0, Culture=neutral, PublicKeyToken=8d05b1bb7a6fdb6c, processorArchitecture=MSIL">
       <HintPath>..\packages\xunit.abstractions.2.0.1\lib\net35\xunit.abstractions.dll</HintPath>
     </Reference>
@@ -90,6 +95,7 @@
   </Choose>
   <ItemGroup>
     <Compile Include="Algorithms\HungarianAlgorithmTests.cs" />
+    <Compile Include="Collections\DirectedAcyclicGraphTests.cs" />
     <Compile Include="Collections\PrefixTrieTests.cs" />
     <Compile Include="Algorithms\BinPackingTests.cs" />
     <Compile Include="Collections\PriorityQueueTests.cs" />

--- a/tests/Collections/DirectedAcyclicGraphTests.cs
+++ b/tests/Collections/DirectedAcyclicGraphTests.cs
@@ -1,0 +1,336 @@
+﻿using System;
+using Bearded.Utilities.Collections;
+using FluentAssertions;
+using Xunit;
+
+namespace Bearded.Utilities.Tests.Collections
+{
+    public class DirectedAcyclicGraphTests
+    {
+        [Fact]
+        public void AddElement_AddsElement()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.AddElement("element");
+
+            graph.Elements.Should().Contain("element");
+        }
+
+        [Fact]
+        public void AddElement_IncreasesCount()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.AddElement("element");
+
+            graph.Count.Should().Be(1);
+        }
+
+        [Fact]
+        public void AddElement_ShouldThrowOnNull()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.Invoking(g => g.AddElement(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void AddElement_DoesNotAddOutgoingEdges()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.AddElement("element");
+
+            graph.GetOutgoingEdgesFor("element").Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddElement_DoesNotAddIncomingEdges()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.AddElement("element");
+
+            graph.GetIncomingEdgesFor("element").Should().BeEmpty();
+        }
+
+        [Fact]
+        public void AddEdge_AddsOutgoingEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+            graph.AddElement("to");
+
+            graph.AddEdge("from", "to");
+
+            graph.GetOutgoingEdgesFor("from").Should().Contain("to");
+        }
+
+        [Fact]
+        public void AddEdge_AddsIncomingEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+            graph.AddElement("to");
+
+            graph.AddEdge("from", "to");
+
+            graph.GetIncomingEdgesFor("to").Should().Contain("from");
+        }
+
+        [Fact]
+        public void AddEdge_ThrowsOnMissingFrom()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("to");
+
+            graph.Invoking(g => g.AddEdge("from", "to")).Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void AddEdge_ThrowsOnMissingTo()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+
+            graph.Invoking(g => g.AddEdge("from", "to")).Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void AddEdge_ThrowsOnNullFrom()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("to");
+
+            graph.Invoking(g => g.AddEdge(null, "to")).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void AddEdge_ThrowsOnNullTo()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+
+            graph.Invoking(g => g.AddEdge("from", null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void AddEdge_ThrowsOnFromAndToEqual()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("element");
+            
+            graph.Invoking(g => g.AddEdge("element", "element")).Should().Throw<InvalidOperationException>();
+        }
+
+        [Fact]
+        public void RemoveElement_RemovesElement()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("element");
+
+            graph.RemoveElement("element");
+
+            graph.Elements.Should().NotContain("element");
+        }
+        
+        [Fact]
+        public void RemoveElement_ReducesCount()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("element");
+
+            graph.RemoveElement("element");
+
+            graph.Count.Should().Be(0);
+        }
+        
+        [Fact]
+        public void RemoveElement_ReturnsTrueForExisting()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("element");
+
+            graph.RemoveElement("element").Should().BeTrue();
+        }
+        
+        
+        [Fact]
+        public void RemoveElement_ReturnsFalseForNonExisting()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.RemoveElement("element").Should().BeFalse();
+        }
+
+        [Fact]
+        public void RemoveElement_ThrowsOnNull()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+
+            graph.Invoking(g => g.RemoveElement(null)).Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void RemoveElement_RemovesItAsOutgoingEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("element");
+            graph.AddElement("incoming");
+            graph.AddEdge("incoming", "element");
+            
+            graph.RemoveElement("element");
+
+            graph.GetOutgoingEdgesFor("incoming").Should().NotContain("element");
+        }
+        
+        [Fact]
+        public void RemoveElement_RemovesItAsIncomingEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("element");
+            graph.AddElement("outgoing");
+            graph.AddEdge("element", "outgoing");
+            
+            graph.RemoveElement("element");
+
+            graph.GetIncomingEdgesFor("outgoing").Should().NotContain("element");
+        }
+
+        [Fact]
+        public void RemoveEdge_RemovesOutgoingEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+            graph.AddElement("to");
+            graph.AddEdge("from", "to");
+
+            graph.RemoveEdge("from", "to");
+
+            graph.GetOutgoingEdgesFor("from").Should().NotContain("to");
+        }
+
+        [Fact]
+        public void RemoveEdge_RemovesIncomingEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+            graph.AddElement("to");
+            graph.AddEdge("from", "to");
+            
+            graph.RemoveEdge("from", "to");
+
+            graph.GetIncomingEdgesFor("to").Should().NotContain("from");
+        }
+
+        [Fact]
+        public void RemoveEdge_ReturnsTrueOnExisting()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+            graph.AddElement("to");
+            graph.AddEdge("from", "to");
+            
+            graph.RemoveEdge("from", "to").Should().BeTrue();
+        }
+
+        [Fact]
+        public void RemoveEdge_ReturnsFalseOnNonExisting()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+            graph.AddElement("to");
+            
+            graph.RemoveEdge("from", "to").Should().BeFalse();
+        }
+
+        [Fact]
+        public void RemoveEdge_ThrowsOnFromMissing()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("to");
+
+            graph.Invoking(g => g.RemoveEdge("from", "to")).Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void RemoveEdge_ThrowsOnToMissing()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+
+            graph.Invoking(g => g.RemoveEdge("from", "to")).Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void RemoveEdge_ThrowsOnFromNull()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("to");
+
+            graph.Invoking(g => g.RemoveEdge(null, "to")).Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void RemoveEdge_ThrowsOnToNull()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("from");
+
+            graph.Invoking(g => g.RemoveEdge("from", null)).Should().Throw<ArgumentException>();
+        }
+
+        [Fact]
+        public void GetTransitiveReduction_DoesNotRemoveElements()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("one");
+            graph.AddElement("two");
+            graph.AddElement("three");
+            graph.AddEdge("one", "two");
+            graph.AddEdge("two", "three");
+            graph.AddEdge("one", "three");
+            
+            var reducedGraph = graph.GetTransitiveReduction();
+
+            reducedGraph.Elements.Should().Contain(graph.Elements);
+        }
+
+        [Fact]
+        public void GetTransitiveReduction_RemovesTransitiveEdge()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("one");
+            graph.AddElement("two");
+            graph.AddElement("three");
+            graph.AddEdge("one", "two");
+            graph.AddEdge("two", "three");
+            graph.AddEdge("one", "three");
+
+            var reducedGraph = graph.GetTransitiveReduction();
+
+            reducedGraph.GetOutgoingEdgesFor("one").Should().NotContain("three");
+            reducedGraph.GetIncomingEdgesFor("three").Should().NotContain("one");
+        }
+
+        [Fact]
+        public void GetTransitiveReduction_KeepsRequiredEdges()
+        {
+            var graph = new DirectedAcyclicGraph<string>();
+            graph.AddElement("one");
+            graph.AddElement("two");
+            graph.AddElement("three");
+            graph.AddEdge("one", "two");
+            graph.AddEdge("two", "three");
+            graph.AddEdge("one", "three");
+
+            var reducedGraph = graph.GetTransitiveReduction();
+
+            reducedGraph.GetOutgoingEdgesFor("one").Should().Contain("two");
+            reducedGraph.GetIncomingEdgesFor("two").Should().Contain("one");
+            reducedGraph.GetOutgoingEdgesFor("two").Should().Contain("three");
+            reducedGraph.GetIncomingEdgesFor("three").Should().Contain("two");
+        }
+    }
+}

--- a/tests/packages.config
+++ b/tests/packages.config
@@ -1,10 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
+  <package id="FluentAssertions" version="5.4.2" targetFramework="net462" />
   <package id="FsCheck" version="2.9.0" targetFramework="net462" />
   <package id="FsCheck.Xunit" version="2.9.0" targetFramework="net462" />
   <package id="FSharp.Core" version="4.1.17" targetFramework="net462" />
   <package id="OpenTK" version="2.0.0" targetFramework="net462" />
-  <package id="System.ValueTuple" version="4.3.0" targetFramework="net462" />
+  <package id="System.ValueTuple" version="4.4.0" targetFramework="net462" />
   <package id="xunit" version="2.2.0" targetFramework="net462" />
   <package id="xunit.abstractions" version="2.0.1" targetFramework="net462" />
   <package id="xunit.assert" version="2.2.0" targetFramework="net462" />


### PR DESCRIPTION
Adds a directed acyclic graph class. This seems to be the easiest way to represent a partial ordering, which is something I need for an algorithm I want to add to this library.