### PR TITLE
Remove unnecessary method

### DIFF
--- a/src/Core/Do.cs
+++ b/src/Core/Do.cs
@@ -2,11 +2,6 @@
 {
     public static class Do
     {
-        public static void Swap<T>(ref T a, ref T b)
-        {
-            (a, b) = (b, a);
-        }
-
         public static Box<T> Box<T>(T value)
             where T : struct
             => new Box<T>(value);


### PR DESCRIPTION
Might as well just do what this method does wherever this is used.