### PR TITLE
Add a project for testing utilities

### DIFF
--- a/Bearded.Utilities.sln
+++ b/Bearded.Utilities.sln
@@ -7,6 +7,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bearded.Utilities", "src\Be
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bearded.Utilities.Tests", "tests\Bearded.Utilities.Tests.csproj", "{7EDB76CB-E9DC-4BCC-A610-12BE4976A701}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Bearded.Utilities.Testing", "testing\Bearded.Utilities.Testing.csproj", "{C83131DC-2AD2-4B35-BD77-735A937B70C7}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -21,6 +23,10 @@ Global
 		{7EDB76CB-E9DC-4BCC-A610-12BE4976A701}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{7EDB76CB-E9DC-4BCC-A610-12BE4976A701}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{7EDB76CB-E9DC-4BCC-A610-12BE4976A701}.Release|Any CPU.Build.0 = Release|Any CPU
+		{C83131DC-2AD2-4B35-BD77-735A937B70C7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{C83131DC-2AD2-4B35-BD77-735A937B70C7}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{C83131DC-2AD2-4B35-BD77-735A937B70C7}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{C83131DC-2AD2-4B35-BD77-735A937B70C7}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,6 +24,7 @@ build:
   verbosity: minimal
 before_package:
 - ps: nuget pack $env:appveyor_build_folder/src/Bearded.Utilities.csproj -version $env:nuget_version
+- ps: nuget pack $env:appveyor_build_folder/src/Bearded.Utilities.Testing.csproj -version $env:nuget_version
 test:
   assemblies:
     only:

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -24,7 +24,7 @@ build:
   verbosity: minimal
 before_package:
 - ps: nuget pack $env:appveyor_build_folder/src/Bearded.Utilities.csproj -version $env:nuget_version
-- ps: nuget pack $env:appveyor_build_folder/src/Bearded.Utilities.Testing.csproj -version $env:nuget_version
+- ps: nuget pack $env:appveyor_build_folder/testing/Bearded.Utilities.Testing.csproj -version $env:nuget_version
 test:
   assemblies:
     only:

--- a/testing/Bearded.Utilities.Testing.csproj
+++ b/testing/Bearded.Utilities.Testing.csproj
@@ -1,0 +1,5 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net462</TargetFramework>
+  </PropertyGroup>
+</Project>

--- a/testing/Bearded.Utilities.Testing.nuspec
+++ b/testing/Bearded.Utilities.Testing.nuspec
@@ -1,0 +1,17 @@
+<?xml version="1.0"?>
+<package >
+  <metadata>
+    <id>Bearded.Utilities.Testing</id>
+    <version>$version$</version>
+    <title>$title$</title>
+    <authors>$author$</authors>
+    <owners>$author$</owners>
+    <licenseUrl>https://github.com/beardgame/utilities/blob/develop/LICENSE</licenseUrl>
+    <projectUrl>https://github.com/beardgame/utilities</projectUrl>
+    <requireLicenseAcceptance>false</requireLicenseAcceptance>
+    <description>Testing utilities that can be used for testing types from Bearded.Utilities.</description>
+    <releaseNotes>Initial release.</releaseNotes>
+    <copyright>Copyright 2019</copyright>
+    <tags>gamedev</tags>
+  </metadata>
+</package>

--- a/testing/Class1.cs
+++ b/testing/Class1.cs
@@ -1,0 +1,4 @@
+﻿namespace Bearded.Utilities.Testing
+{
+    public class Class1 { }
+}

--- a/testing/Class1.cs
+++ b/testing/Class1.cs
@@ -1,4 +1,0 @@
-﻿namespace Bearded.Utilities.Testing
-{
-    public class Class1 { }
-}


### PR DESCRIPTION
This PR adds a new project that can contain testing utilities. These testing utilities are meant to be used to make testing easier if you use some of our types (such as Maybe) by abstracting away common checks.