### PR TITLE
Add Random tests

### DIFF
--- a/Bearded.Utilities.Tests/Algorithms/BinPackingTests.cs
+++ b/Bearded.Utilities.Tests/Algorithms/BinPackingTests.cs
@@ -11,7 +11,7 @@ namespace Bearded.Utilities.Tests.Algorithms
         [Fact]
         public void TestPackedRectangles_IncludesAll()
         {
-            var random = new Random(0);
+            var random = new System.Random(0);
             var input = Enumerable.Range(0, 100)
                 .Select(i => new BinPacking.Rectangle<int>(i, random.Next(5, 20), random.Next(5, 20)))
                 .ToList();
@@ -36,7 +36,7 @@ namespace Bearded.Utilities.Tests.Algorithms
         [Fact]
         public void TestPackedRectangles_NoOverlap()
         {
-            var random = new Random(0);
+            var random = new System.Random(0);
             var input = Enumerable.Range(0, 100)
                 .Select(i => new BinPacking.Rectangle<int>(i, random.Next(5, 20), random.Next(5, 20)))
                 .ToList();
@@ -63,7 +63,7 @@ namespace Bearded.Utilities.Tests.Algorithms
         [Fact]
         public void TestPackedRectangles_CorrectResultStatistics()
         {
-            var random = new Random(0);
+            var random = new System.Random(0);
             var input = Enumerable.Range(0, 100)
                 .Select(i => new BinPacking.Rectangle<int>(i, random.Next(5, 20), random.Next(5, 20)))
                 .ToList();
@@ -99,7 +99,7 @@ namespace Bearded.Utilities.Tests.Algorithms
         [Fact]
         public void TestPackedRectangles_MultipleHeuristicsEqualOrBetter()
         {
-            var random = new Random(0);
+            var random = new System.Random(0);
             var input = Enumerable.Range(0, 100)
                 .Select(i => new BinPacking.Rectangle<int>(i, random.Next(5, 20), random.Next(5, 20)))
                 .ToList();

--- a/Bearded.Utilities.Tests/Collections/DeletableObjectListTests.cs
+++ b/Bearded.Utilities.Tests/Collections/DeletableObjectListTests.cs
@@ -7,7 +7,6 @@ using Bearded.Utilities.Linq;
 using FsCheck;
 using FsCheck.Xunit;
 using Xunit;
-using Random = System.Random;
 
 namespace Bearded.Utilities.Tests.Collections
 {
@@ -159,7 +158,7 @@ namespace Bearded.Utilities.Tests.Collections
 
         public class TheRemoveMethod : MethodThatDoesNotThrowsWhenEnumeratingTests
         {
-            private readonly Random random = new Random(0);
+            private readonly System.Random random = new System.Random(0);
 
             protected override void CallMethod(DeletableObjectList<TestDeletable> list)
                 => list.Remove(list.RandomElement(random));
@@ -497,7 +496,7 @@ namespace Bearded.Utilities.Tests.Collections
             public void IsAccurateWhenAddingAndRemoving(PositiveInt itemsToAdd, int randomSeed)
             {
                 var itemCount = itemsToAdd.Get;
-                var random = new Random(randomSeed);
+                var random = new System.Random(randomSeed);
                 var list = new DeletableObjectList<TestDeletable>();
 
                 foreach (var i in Enumerable.Range(1, itemCount))
@@ -517,7 +516,7 @@ namespace Bearded.Utilities.Tests.Collections
             public void IsAccurateAfterEnumerating(PositiveInt itemsToAdd, int randomSeed)
             {
                 var itemCount = itemsToAdd.Get;
-                var random = new Random(randomSeed);
+                var random = new System.Random(randomSeed);
                 var (list, items) = createPopulatedList(itemCount);
                 items.RandomElement(random).Deleted = true;
 

--- a/Bearded.Utilities.Tests/Core/Random/BaseTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/BaseTests.cs
@@ -1,6 +1,6 @@
 using System;
 
-namespace Bearded.Utilities.Tests.Core.Random
+namespace Bearded.Utilities.Tests.Random
 {
     public class BaseTests
     {

--- a/Bearded.Utilities.Tests/Core/Random/BaseTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/BaseTests.cs
@@ -1,0 +1,65 @@
+using System;
+
+namespace Bearded.Utilities.Tests.Core.Random
+{
+    public class BaseTests
+    {
+        public abstract class RandomMethodWithoutParameters<T>
+            where T : struct, IComparable<T>
+        {
+            protected Func<T> CallingWith(int seed)
+                => () => ResultOfCallingWith(seed);
+
+            protected T ResultOfCallingWith(int seed)
+            {
+                Seed(seed);
+                return CallMethod();
+            }
+
+            protected abstract T CallMethod();
+
+            protected abstract void Seed(int seed);
+        }
+
+        public abstract class RandomMethodWithOneParameter<T>
+            : RandomMethodWithOneParameter<T, T>
+            where T : struct, IComparable<T>
+        {
+            
+        }
+        
+        public abstract class RandomMethodWithOneParameter<T, TParameter>
+            where T : struct, IComparable<T>
+        {
+            protected Func<T> CallingWith(int seed, TParameter parameter)
+                => () => ResultOfCallingWith(seed, parameter);
+
+            protected T ResultOfCallingWith(int seed, TParameter parameter)
+            {
+                Seed(seed);
+                return CallMethod(parameter);
+            }
+
+            protected abstract T CallMethod(TParameter parameter);
+
+            protected abstract void Seed(int seed);
+        }
+
+        public abstract class RandomMethodWithTwoParameters<T>
+            where T : struct, IComparable<T>
+        {
+            protected Func<T> CallingWith(int seed, T parameter1, T parameter2)
+                => () => ResultOfCallingWith(seed, parameter1, parameter2);
+
+            protected T ResultOfCallingWith(int seed, T parameter1, T parameter2)
+            {
+                Seed(seed);
+                return CallMethod(parameter1, parameter2);
+            }
+
+            protected abstract T CallMethod(T parameter1, T parameter2);
+
+            protected abstract void Seed(int seed);
+        }
+    }
+}

--- a/Bearded.Utilities.Tests/Core/Random/BaseTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/BaseTests.cs
@@ -4,7 +4,27 @@ namespace Bearded.Utilities.Tests.Random
 {
     public class BaseTests
     {
-        public abstract class RandomMethodWithoutParameters<T>
+        public abstract class RandomMethodBase<TMethod>
+        {
+            // ReSharper disable once VirtualMemberCallInConstructor
+            // it's magic to make actual tests more concise, yet enforce implementing setup
+            // (though we can't enforce _correct_ implementation)
+            protected RandomMethodBase() => Setup();
+
+            protected abstract void Setup();
+
+            protected void Setup(Action<int> seed, TMethod method)
+            {
+                Seed = seed;
+                CallMethod = method;
+            }
+            
+            public TMethod CallMethod { get; set; }
+
+            public Action<int> Seed { get; set; }
+        }
+        
+        public abstract class RandomMethodWithoutParameters<T> : RandomMethodBase<Func<T>>
             where T : struct, IComparable<T>
         {
             protected Func<T> CallingWith(int seed)
@@ -15,10 +35,6 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 return CallMethod();
             }
-
-            protected abstract T CallMethod();
-
-            protected abstract void Seed(int seed);
         }
 
         public abstract class RandomMethodWithOneParameter<T>
@@ -28,7 +44,7 @@ namespace Bearded.Utilities.Tests.Random
             
         }
         
-        public abstract class RandomMethodWithOneParameter<T, TParameter>
+        public abstract class RandomMethodWithOneParameter<T, TParameter> : RandomMethodBase<Func<TParameter, T>>
             where T : struct, IComparable<T>
         {
             protected Func<T> CallingWith(int seed, TParameter parameter)
@@ -39,13 +55,9 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 return CallMethod(parameter);
             }
-
-            protected abstract T CallMethod(TParameter parameter);
-
-            protected abstract void Seed(int seed);
         }
 
-        public abstract class RandomMethodWithTwoParameters<T>
+        public abstract class RandomMethodWithTwoParameters<T> : RandomMethodBase<Func<T, T, T>>
             where T : struct, IComparable<T>
         {
             protected Func<T> CallingWith(int seed, T parameter1, T parameter2)
@@ -56,10 +68,6 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 return CallMethod(parameter1, parameter2);
             }
-
-            protected abstract T CallMethod(T parameter1, T parameter2);
-
-            protected abstract void Seed(int seed);
         }
     }
 }

--- a/Bearded.Utilities.Tests/Core/Random/RandomExtensionsTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/RandomExtensionsTests.cs
@@ -1,133 +1,138 @@
-using static Bearded.Utilities.StaticRandom;
+using System;
 
 namespace Bearded.Utilities.Tests.Random
 {
-    public class StaticRandomTests
+    public class RandomExtensionsTests
     {
+        private static void setup<T>(BaseTests.RandomMethodBase<T> tests, Func<System.Random, T> getMethod)
+        {
+            tests.Seed = seed => tests.CallMethod = getMethod(new System.Random(seed));
+        }
+        
         public class TheSeedWithMethod : SharedTests.TheSeedMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Int);
+                => setup(this, r => r.Next);
         }
 
         public class TheIntMethod : SharedTests.TheIntMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Int);
+                => setup(this, r => r.Next);
         }
         
         public class TheIntWithMaxMethod : SharedTests.TheIntWithMaxMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Int);
+                => setup(this, r => r.Next);
         }
 
         public class TheIntWithMinAndMaxMethod : SharedTests.TheIntWithMinAndMaxMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Int);
+                => setup(this, r => r.Next);
         }
         
         public class TheLongMethod : SharedTests.TheLongMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Long);
+                => setup(this, r => r.NextLong);
         }
         
         public class TheLongWithMaxMethod : SharedTests.TheLongWithMaxMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Long);
+                => setup(this, r => r.NextLong);
         }
 
         public class TheLongWithMinAndMaxMethod : SharedTests.TheLongWithMinAndMaxMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Long);
+                => setup(this, r => r.NextLong);
         }
 
         public class TheFloatMethod : SharedTests.TheFloatMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Float);
+                => setup(this, r => r.NextFloat);
         }
 
         public class TheFloatWithOneBoundMethod : SharedTests.TheFloatWithOneBoundMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Float);
+                => setup(this, r => r.NextFloat);
         }
 
         public class TheFloatWithTwoBoundsMethod : SharedTests.TheFloatWithTwoBoundsMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Float);
+                => setup(this, r => r.NextFloat);
         }
 
         public class TheDoubleMethod : SharedTests.TheDoubleMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Double);
+                => setup(this, r => r.NextDouble);
         }
 
         public class TheDoubleWithOneBoundMethod : SharedTests.TheDoubleWithOneBoundMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Double);
+                => setup(this, r => r.NextDouble);
         }
 
         public class TheDoubleWithTwoBoundsMethod : SharedTests.TheDoubleWithTwoBoundsMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Double);
+                => setup(this, r => r.NextDouble);
         }
 
         public class TheSignMethod : SharedTests.TheSignMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Sign);
+                => setup(this, r => r.NextSign);
         }
 
         public class TheBoolMethod : SharedTests.TheBoolMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Bool);
+                => setup(this, r => r.NextBool);
         }
         
         public class TheBoolWithParameterMethod : SharedTests.TheBoolWithParameterMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Bool);
+                => setup(this, r => r.NextBool);
         }
 
         public class TheDiscretiseMethod : SharedTests.TheDiscretiseMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, Discretise);
+                => setup(this, r => r.Discretise);
         }
 
         public class TheNormalFloatMethod : SharedTests.TheNormalFloatMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, NormalFloat);
+                => setup(this, r => r.NormalFloat);
         }
 
         public class TheNormalFloatWithParametersMethod : SharedTests.TheNormalFloatWithParametersMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, NormalFloat);
+                => setup(this, r => r.NormalFloat);
         }
 
         public class TheNormalDoubleMethod : SharedTests.TheNormalDoubleMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, NormalDouble);
+                => setup(this, r => r.NormalDouble);
         }
         
         public class TheNormalDoubleWithParametersMethod : SharedTests.TheNormalDoubleWithParametersMethod
         {
             protected override void Setup()
-                => Setup(SeedWith, NormalDouble);
+                => setup(this, r => r.NormalDouble);
         }
     }
 }

--- a/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
@@ -1,0 +1,301 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+
+namespace Bearded.Utilities.Tests.Core.Random
+{
+    public class SharedTests
+    {
+        private static IEnumerable<T> sequence<T>(int count, Func<T> function)
+            => Enumerable.Range(0, count).Select(_ => function());
+
+        private static List<T> list<T>(int count, Func<T> function)
+            => sequence(count, function).ToList();
+        
+        public abstract class TheSeedMethod : BaseTests.RandomMethodWithoutParameters<int>
+        {
+            [Property]
+            public void LeadsToPredictableResultsWithSameSeed(int seed)
+            {
+                Seed(seed);
+                var sequence1 = list(100, CallMethod);
+
+                Seed(seed);
+                var sequence2 = list(100, CallMethod);
+
+                sequence1.Should().BeEquivalentTo(sequence2,
+                    options => options.WithStrictOrdering());
+            }
+        }
+        
+        public abstract class TheIntMethod : BaseTests.RandomMethodWithoutParameters<int>
+        {
+            [Property]
+            public void ShouldReturnDifferentValues(int seed)
+            {
+                Seed(seed);
+                var first = CallMethod();
+
+                sequence(100, CallMethod)
+                    .Should().Contain(i => i != first);
+            }
+        }
+
+        public abstract class TheIntWithMaxMethod : BaseTests.RandomMethodWithOneParameter<int>
+        {
+            [Property]
+            public void ShouldReturnValueInRange(int seed, PositiveInt max)
+            {
+                ResultOfCallingWith(seed, max.Get)
+                    .Should().BeInRange(0, max.Get);
+            }
+
+            [Property]
+            public void ShouldThrowForNegativeMaximum(int seed, NegativeInt max)
+            {
+                CallingWith(seed, max.Get).Should().Throw<ArgumentException>();
+            }
+
+            [Property]
+            public void ShouldReturnZeroForZeroMaximum(int seed)
+            {
+                ResultOfCallingWith(seed, 0).Should().Be(0);
+            }
+        }
+
+        public abstract class TheIntWithMinAndMaxMethod : BaseTests.RandomMethodWithTwoParameters<int>
+        {
+            [Property]
+            public void ShouldReturnValueInRange(int seed, int min, int max)
+            {
+                if (max < min)
+                    (min, max) = (max, min);
+
+                ResultOfCallingWith(seed, min, max)
+                    .Should().BeInRange(min, max);
+            }
+
+            [Property]
+            public void ShouldThrowIfMaximumLessThanMinimum(int seed, int min, int max)
+            {
+                if (max == min)
+                    max--;
+                if (max > min)
+                    (min, max) = (max, min);
+
+                CallingWith(seed, min, max)
+                    .Should().Throw<ArgumentException>();
+            }
+
+            [Property]
+            public void ShouldReturnMinimumIfMinimumEqualsMaximum(int seed, int minMax)
+            {
+                ResultOfCallingWith(seed, minMax, minMax)
+                    .Should().Be(minMax);
+            }
+        }
+        
+        public abstract class TheFloatMethod : BaseTests.RandomMethodWithoutParameters<float>
+        {
+            [Property]
+            public void ShouldReturnDifferentValues(int seed)
+            {
+                Seed(seed);
+                var first = CallMethod();
+
+                // ReSharper disable once CompareOfFloatsByEqualityOperator
+                sequence(100, CallMethod)
+                    .Should().Contain(i => i != first);
+            }
+            
+            [Property]
+            public void ShouldReturnValuesInUnitRange(int seed)
+            {
+                ResultOfCallingWith(seed).Should().BeInRange(0, 1);
+            }
+        }
+        
+        public abstract class TheFloatWithOneBoundMethod : BaseTests.RandomMethodWithOneParameter<float>
+        {
+            [Property]
+            public void ShouldReturnValueInRange(int seed, float bound)
+            {
+                var (minimumValue, maximumValue) = bound > 0
+                    ? (0f, bound)
+                    : (bound, 0f);
+                
+                ResultOfCallingWith(seed, bound)
+                    .Should().BeInRange(minimumValue, maximumValue);
+            }
+
+            [Property]
+            public void ShouldReturnZeroForZeroBound(int seed)
+            {
+                ResultOfCallingWith(seed, 0).Should().Be(0);
+            }
+        }
+
+        public abstract class TheFloatWithTwoBoundsMethod : BaseTests.RandomMethodWithTwoParameters<float>
+        {
+            [Property]
+            public void ShouldReturnValueInRange(int seed, int bound1, int bound2)
+            {
+                var (minimumValue, maximumValue) = bound1 < bound2
+                    ? (bound1, bound2)
+                    : (bound2, bound1);
+
+                ResultOfCallingWith(seed, bound1, bound2)
+                    .Should().BeInRange(minimumValue, maximumValue);
+            }
+
+            [Property]
+            public void ShouldReturnBoundIfBoundsAreEqual(int seed, int bound)
+            {
+                ResultOfCallingWith(seed, bound, bound)
+                    .Should().Be(bound);
+            }
+        }
+        public abstract class TheDoubleMethod : BaseTests.RandomMethodWithoutParameters<double>
+        {
+            [Property]
+            public void ShouldReturnDifferentValues(int seed)
+            {
+                Seed(seed);
+                var first = CallMethod();
+
+                // ReSharper disable once CompareOfDoublesByEqualityOperator
+                sequence(100, CallMethod)
+                    .Should().Contain(i => i != first);
+            }
+            
+            [Property]
+            public void ShouldReturnValuesInUnitRange(int seed)
+            {
+                ResultOfCallingWith(seed).Should().BeInRange(0, 1);
+            }
+        }
+        
+        public abstract class TheDoubleWithOneBoundMethod : BaseTests.RandomMethodWithOneParameter<double>
+        {
+            [Property]
+            public void ShouldReturnValueInRange(int seed, double bound)
+            {
+                var (minimumValue, maximumValue) = bound > 0
+                    ? (0d, bound)
+                    : (bound, 0d);
+                
+                ResultOfCallingWith(seed, bound)
+                    .Should().BeInRange(minimumValue, maximumValue);
+            }
+
+            [Property]
+            public void ShouldReturnZeroForZeroBound(int seed)
+            {
+                ResultOfCallingWith(seed, 0).Should().Be(0);
+            }
+        }
+
+        public abstract class TheDoubleWithTwoBoundsMethod : BaseTests.RandomMethodWithTwoParameters<double>
+        {
+            [Property]
+            public void ShouldReturnValueInRange(int seed, int bound1, int bound2)
+            {
+                var (minimumValue, maximumValue) = bound1 < bound2
+                    ? (bound1, bound2)
+                    : (bound2, bound1);
+
+                ResultOfCallingWith(seed, bound1, bound2)
+                    .Should().BeInRange(minimumValue, maximumValue);
+            }
+
+            [Property]
+            public void ShouldReturnBoundIfBoundsAreEqual(int seed, int bound)
+            {
+                ResultOfCallingWith(seed, bound, bound)
+                    .Should().Be(bound);
+            }
+        }
+
+        public abstract class TheSignMethod : BaseTests.RandomMethodWithoutParameters<int>
+        {
+            [Property]
+            public void ReturnsPlusOrMinusOne(int seed)
+            {
+                ResultOfCallingWith(seed).Should().BeOneOf(-1, 1);
+            }
+
+            [Property]
+            public void ReturnsBothValidValues(int seed)
+            {
+                Seed(seed);
+                sequence(100, CallMethod)
+                    .Should().Contain(new []{-1, 1});
+            }
+        }
+
+        public abstract class TheBoolMethod : BaseTests.RandomMethodWithoutParameters<bool>
+        {
+            [Property]
+            public void ReturnsBothPossibleValues(int seed)
+            {
+                Seed(seed);
+                sequence(100, CallMethod)
+                    .Should().Contain(new []{true, false});
+            }
+        }
+        
+        public abstract class TheBoolWithParameterMethod : BaseTests.RandomMethodWithOneParameter<bool, double>
+        {
+            [Property]
+            public void ReturnsOnlyFalseForZeroParameter(int seed)
+            {
+                ResultOfCallingWith(seed, 0).Should().Be(false);
+            }
+            
+            [Property]
+            public void ReturnsOnlyTrueForOneParameter(int seed)
+            {
+                ResultOfCallingWith(seed, 1).Should().Be(true);
+            }
+            
+            [Property]
+            public void ReturnsOnlyFalseForNegativeParameter(int seed, NegativeInt negativeInt)
+            {
+                ResultOfCallingWith(seed, negativeInt.Get).Should().Be(false);
+            }
+            
+            [Property]
+            public void ReturnsOnlyTrueForParameterLargerThanOne(int seed, PositiveInt positiveInt)
+            {
+                ResultOfCallingWith(seed, positiveInt.Get).Should().Be(true);
+            }
+            
+            [Property]
+            public void ReturnsBothPossibleValues(int seed)
+            {
+                Seed(seed);
+                sequence(100, () => CallMethod(0.5f))
+                    .Should().Contain(new []{true, false});
+            }
+        }
+
+        public abstract class TheDiscretiseMethod : BaseTests.RandomMethodWithOneParameter<int, float>
+        {
+            [Property]
+            public void ReturnsTheSameValueForIntegerParameters(int seed, int parameter)
+            {
+                ResultOfCallingWith(seed, parameter).Should().Be(parameter);
+            }
+
+            [Property]
+            public void ReturnsEitherFloorOrCeilOfParameter(int seed, float parameter)
+            {
+                ResultOfCallingWith(seed, parameter)
+                    .Should().BeOneOf((int)Math.Floor(parameter), (int)Math.Ceiling(parameter));
+            }
+        }
+    }
+}

--- a/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
@@ -237,7 +237,6 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
 
-                // ReSharper disable once CompareOfDoublesByEqualityOperator
                 sequence(100, CallMethod)
                     .Should().Contain(i => i != first);
             }

--- a/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using FluentAssertions;
 using FsCheck;
 using FsCheck.Xunit;
+// ReSharper disable CompareOfFloatsByEqualityOperator because we mean to test equality below
 
 namespace Bearded.Utilities.Tests.Random
 {
@@ -175,7 +176,6 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
 
-                // ReSharper disable once CompareOfFloatsByEqualityOperator
                 sequence(100, CallMethod)
                     .Should().Contain(i => i != first);
             }
@@ -349,7 +349,7 @@ namespace Bearded.Utilities.Tests.Random
             [Property]
             public void ReturnsBothPossibleValues(int seed, byte parameter)
             {
-                // ensure 0<<p<<1
+                // ensure 0<<p<<1 to ensure the test is very likely to pass
                 var p = 0.5f + (parameter - byte.MaxValue * 0.5f) / (3f * byte.MaxValue);
                 Seed(seed);
                 sequence(100, () => CallMethod(p))

--- a/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/SharedTests.cs
@@ -10,6 +10,9 @@ namespace Bearded.Utilities.Tests.Random
 {
     public class SharedTests
     {
+        private const int sequenceCount = 100;
+        private const int diviationOffset = 100;
+        
         private static IEnumerable<T> sequence<T>(int count, Func<T> function)
             => Enumerable.Range(0, count).Select(_ => function());
 
@@ -22,10 +25,10 @@ namespace Bearded.Utilities.Tests.Random
             public void LeadsToPredictableResultsWithSameSeed(int seed)
             {
                 Seed(seed);
-                var sequence1 = list(100, CallMethod);
+                var sequence1 = list(sequenceCount, CallMethod);
 
                 Seed(seed);
-                var sequence2 = list(100, CallMethod);
+                var sequence2 = list(sequenceCount, CallMethod);
 
                 sequence1.Should().BeEquivalentTo(sequence2,
                     options => options.WithStrictOrdering());
@@ -40,7 +43,7 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
 
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(i => i != first);
             }
         }
@@ -107,7 +110,7 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
 
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(i => i != first);
             }
         }
@@ -176,7 +179,7 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
 
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(i => i != first);
             }
             
@@ -237,7 +240,7 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
 
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(i => i != first);
             }
             
@@ -286,7 +289,7 @@ namespace Bearded.Utilities.Tests.Random
             [Property]
             public void ShouldReturnBoundIfBoundsAreEqual(int seed, NormalFloat bound)
             {
-                var b = (float) bound.Get;
+                var b = bound.Get;
                 ResultOfCallingWith(seed, b, b).Should().Be(b);
             }
         }
@@ -303,7 +306,7 @@ namespace Bearded.Utilities.Tests.Random
             public void ReturnsBothValidValues(int seed)
             {
                 Seed(seed);
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(new []{-1, 1});
             }
         }
@@ -314,7 +317,7 @@ namespace Bearded.Utilities.Tests.Random
             public void ReturnsBothPossibleValues(int seed)
             {
                 Seed(seed);
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(new []{true, false});
             }
         }
@@ -351,7 +354,7 @@ namespace Bearded.Utilities.Tests.Random
                 // ensure 0<<p<<1 to ensure the test is very likely to pass
                 var p = 0.5f + (parameter - byte.MaxValue * 0.5f) / (3f * byte.MaxValue);
                 Seed(seed);
-                sequence(100, () => CallMethod(p))
+                sequence(sequenceCount, () => CallMethod(p))
                     .Should().Contain(new []{true, false});
             }
         }
@@ -381,7 +384,7 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
                 
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(f => f != first);
             }
         }
@@ -392,9 +395,9 @@ namespace Bearded.Utilities.Tests.Random
             public void ReturnsValuesOtherThanMeanForNonZeroDeviation(int seed, int mean, short deviation)
             {
                 var m = (float) mean;
-                var d = (float) deviation + deviation > 0 ? 100 : -100;
+                var d = (float) deviation + deviation > 0 ? diviationOffset : -diviationOffset;
                 Seed(seed);
-                sequence(100, () => CallMethod(m, d))
+                sequence(sequenceCount, () => CallMethod(m, d))
                     .Should().Contain(f => f != m);
             }
 
@@ -413,7 +416,7 @@ namespace Bearded.Utilities.Tests.Random
                 Seed(seed);
                 var first = CallMethod();
                 
-                sequence(100, CallMethod)
+                sequence(sequenceCount, CallMethod)
                     .Should().Contain(d => d != first);
             }
         }
@@ -424,9 +427,9 @@ namespace Bearded.Utilities.Tests.Random
             public void ReturnsValuesOtherThanMeanForNonZeroDeviation(int seed, int mean, short deviation)
             {
                 var m = (double) mean;
-                var d = (double) deviation + deviation > 0 ? 100 : -100;
+                var d = (double) deviation + deviation > 0 ? diviationOffset : -diviationOffset;
                 Seed(seed);
-                sequence(100, () => CallMethod(m, d))
+                sequence(sequenceCount, () => CallMethod(m, d))
                     .Should().Contain(f => f != m);
             }
 

--- a/Bearded.Utilities.Tests/Core/Random/StaticRandomTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/StaticRandomTests.cs
@@ -1,0 +1,135 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using FluentAssertions;
+using FsCheck.Xunit;
+
+namespace Bearded.Utilities.Tests.Core.Random
+{
+    public class StaticRandomTests
+    {
+        public class TheSeedWithMethod : SharedTests.TheSeedMethod
+        {
+            protected override int CallMethod()
+                => StaticRandom.Int();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheIntMethod : SharedTests.TheIntMethod
+        {
+            protected override int CallMethod()
+                => StaticRandom.Int();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+        
+        public class TheIntWithMaxMethod : SharedTests.TheIntWithMaxMethod
+        {
+            protected override int CallMethod(int parameter) => StaticRandom.Int(parameter);
+
+            protected override void Seed(int seed) => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheIntWithMinAndMaxMethod : SharedTests.TheIntWithMinAndMaxMethod
+        {
+            protected override int CallMethod(int parameter1, int parameter2)
+                => StaticRandom.Int(parameter1, parameter2);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheFloatMethod : SharedTests.TheFloatMethod
+        {
+            protected override float CallMethod()
+                => StaticRandom.Float();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheFloatWithOneBoundMethod : SharedTests.TheFloatWithOneBoundMethod
+        {
+            protected override float CallMethod(float parameter)
+                => StaticRandom.Float(parameter);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheFloatWithTwoBoundsMethod : SharedTests.TheFloatWithTwoBoundsMethod
+        {
+            protected override float CallMethod(float parameter1, float parameter2)
+                => StaticRandom.Float(parameter1, parameter2);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheDoubleMethod : SharedTests.TheDoubleMethod
+        {
+            protected override double CallMethod()
+                => StaticRandom.Double();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheDoubleWithOneBoundMethod : SharedTests.TheDoubleWithOneBoundMethod
+        {
+            protected override double CallMethod(double parameter)
+                => StaticRandom.Double(parameter);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheDoubleWithTwoBoundsMethod : SharedTests.TheDoubleWithTwoBoundsMethod
+        {
+            protected override double CallMethod(double parameter1, double parameter2)
+                => StaticRandom.Double(parameter1, parameter2);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheSignMethod : SharedTests.TheSignMethod
+        {
+            protected override int CallMethod()
+                => StaticRandom.Sign();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheBoolMethod : SharedTests.TheBoolMethod
+        {
+            protected override bool CallMethod()
+                => StaticRandom.Bool();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+        
+        public class TheBoolWithParameterMethod : SharedTests.TheBoolWithParameterMethod
+        {
+            protected override bool CallMethod(double parameter)
+                => StaticRandom.Bool(parameter);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheDiscretiseMethod : SharedTests.TheDiscretiseMethod
+        {
+            protected override int CallMethod(float parameter)
+                => StaticRandom.Discretise(parameter);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+    }
+}

--- a/Bearded.Utilities.Tests/Core/Random/StaticRandomTests.cs
+++ b/Bearded.Utilities.Tests/Core/Random/StaticRandomTests.cs
@@ -1,10 +1,5 @@
-using System;
-using System.Collections.Generic;
-using System.Linq;
-using FluentAssertions;
-using FsCheck.Xunit;
 
-namespace Bearded.Utilities.Tests.Core.Random
+namespace Bearded.Utilities.Tests.Random
 {
     public class StaticRandomTests
     {
@@ -37,6 +32,33 @@ namespace Bearded.Utilities.Tests.Core.Random
         {
             protected override int CallMethod(int parameter1, int parameter2)
                 => StaticRandom.Int(parameter1, parameter2);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+        
+        public class TheLongMethod : SharedTests.TheLongMethod
+        {
+            protected override long CallMethod()
+                => StaticRandom.Long();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+        
+        public class TheLongWithMaxMethod : SharedTests.TheLongWithMaxMethod
+        {
+            protected override long CallMethod(long parameter)
+                => StaticRandom.Long(parameter);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheLongWithMinAndMaxMethod : SharedTests.TheLongWithMinAndMaxMethod
+        {
+            protected override long CallMethod(long parameter1, long parameter2)
+                => StaticRandom.Long(parameter1, parameter2);
 
             protected override void Seed(int seed)
                 => StaticRandom.SeedWith(seed);
@@ -127,6 +149,42 @@ namespace Bearded.Utilities.Tests.Core.Random
         {
             protected override int CallMethod(float parameter)
                 => StaticRandom.Discretise(parameter);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheNormalFloatMethod : SharedTests.TheNormalFloatMethod
+        {
+            protected override float CallMethod()
+                => StaticRandom.NormalFloat();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheNormalFloatWithParametersMethod : SharedTests.TheNormalFloatWithParametersMethod
+        {
+            protected override float CallMethod(float parameter1, float parameter2)
+                => StaticRandom.NormalFloat(parameter1, parameter2);
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+
+        public class TheNormalDoubleMethod : SharedTests.TheNormalDoubleMethod
+        {
+            protected override double CallMethod()
+                => StaticRandom.NormalDouble();
+
+            protected override void Seed(int seed)
+                => StaticRandom.SeedWith(seed);
+        }
+        
+        public class TheNormalDoubleWithParametersMethod : SharedTests.TheNormalDoubleWithParametersMethod
+        {
+            protected override double CallMethod(double parameter1, double parameter2)
+                => StaticRandom.NormalDouble(parameter1, parameter2);
 
             protected override void Seed(int seed)
                 => StaticRandom.SeedWith(seed);

--- a/Bearded.Utilities/Core/RandomExtensions.cs
+++ b/Bearded.Utilities/Core/RandomExtensions.cs
@@ -25,11 +25,17 @@ namespace Bearded.Utilities
         /// </summary>
         public static long NextLong(this Random random, long min, long max)
         {
+            if (min == max)
+                return min;
+
+            if (min > max)
+                throw new ArgumentException("Maximum must be larger or equal to minimum bound.");
+
             // "awmygawd this is so biased" - Tom Rijnbeek
             var buf = new byte[8];
             random.NextBytes(buf);
             var longRand = BitConverter.ToInt64(buf, 0);
-            
+
             return System.Math.Abs(longRand % (max - min)) + min;
         }
 


### PR DESCRIPTION
This adds tests for our random extensions and StaticRandom class.

The tests are the same for both, using shared code And minimal dummy implementations of the abstract classes containing the actual tests for each of the two cases.

This provides full coverage, but the tests are by no means complete. I check the boundary conditions for all methods, but I do not actually ensure that the same seed reproduced the same sequence for all methods or that all methods produce different numbers given 'sane' bounds.

What is here is reasonably good though (I think), so I think we should merge it. If we want to we can always improve it later.