### PR TITLE
🚫 Improve Nothing syntax

### DIFF
--- a/Bearded.Utilities.Testing.Tests/Core/MaybeAssertionsTests.cs
+++ b/Bearded.Utilities.Testing.Tests/Core/MaybeAssertionsTests.cs
@@ -22,7 +22,7 @@ namespace Bearded.Utilities.Testing.Tests
             [Fact]
             public void FailsWhenNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
                 Action assertion = () => maybe.Should().BeJust();
             
@@ -115,7 +115,7 @@ namespace Bearded.Utilities.Testing.Tests
             [Fact]
             public void FailsWhenNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
                 Action assertion = () => maybe.Should().BeJust(200);
             
@@ -128,7 +128,7 @@ namespace Bearded.Utilities.Testing.Tests
             [Fact]
             public void SucceedsWhenNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
                 Action assertion = () => maybe.Should().BeNothing();
             

--- a/Bearded.Utilities.Tests/Core/MaybeTests.cs
+++ b/Bearded.Utilities.Tests/Core/MaybeTests.cs
@@ -12,7 +12,7 @@ namespace Bearded.Utilities.Tests
             [Fact]
             public void ReturnsDefaultOnNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
                 maybe.ValueOrDefault(100).Should().Be(100);
             }
@@ -31,9 +31,9 @@ namespace Bearded.Utilities.Tests
             [Fact]
             public void MapsNothingToNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
-                maybe.Select(i => i * 2).Should().Be(Maybe.Nothing<int>());
+                maybe.Select(i => i * 2).Should().Be(Maybe<int>.Nothing);
             }
 
             [Fact]
@@ -50,9 +50,9 @@ namespace Bearded.Utilities.Tests
             [Fact]
             public void MapsNothingToNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
-                maybe.SelectMany(i => Maybe.Just(i * 2)).Should().Be(Maybe.Nothing<int>());
+                maybe.SelectMany(i => Maybe.Just(i * 2)).Should().Be(Maybe<int>.Nothing);
             }
 
             [Fact]
@@ -68,7 +68,7 @@ namespace Bearded.Utilities.Tests
             {
                 var maybe = Maybe.Just(100);
 
-                maybe.SelectMany(i => Maybe.Nothing<int>()).Should().Be(Maybe.Nothing<int>());
+                maybe.SelectMany(i => Maybe<int>.Nothing).Should().Be(Maybe<int>.Nothing);
             }
         }
 
@@ -77,17 +77,17 @@ namespace Bearded.Utilities.Tests
             [Fact]
             public void MapsNothingToNothingIfPredicateReturnsFalse()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
-                maybe.Where(_ => false).Should().Be(Maybe.Nothing<int>());
+                maybe.Where(_ => false).Should().Be(Maybe<int>.Nothing);
             }
             
             [Fact]
             public void MapsNothingToNothingIfPredicateReturnsTrue()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
-                maybe.Where(_ => true).Should().Be(Maybe.Nothing<int>());
+                maybe.Where(_ => true).Should().Be(Maybe<int>.Nothing);
             }
             
             [Fact]
@@ -95,7 +95,7 @@ namespace Bearded.Utilities.Tests
             {
                 var maybe = Maybe.Just(100);
 
-                maybe.Where(_ => false).Should().Be(Maybe.Nothing<int>());
+                maybe.Where(_ => false).Should().Be(Maybe<int>.Nothing);
             }
             
             [Fact]
@@ -113,7 +113,7 @@ namespace Bearded.Utilities.Tests
             [SuppressMessage("ReSharper", "ArgumentsStyleAnonymousFunction")]
             public void CallsOnNothingOnNothing()
             {
-                var maybe = Maybe.Nothing<int>();
+                var maybe = Maybe<int>.Nothing;
 
                 var isCalled = false;
                 maybe.Match(
@@ -147,7 +147,7 @@ namespace Bearded.Utilities.Tests
             [Fact]
             public void ReturnsNothingOnReferenceTypeNull()
             {
-                Maybe.FromNullable((string) null).Should().Be(Maybe.Nothing<string>());
+                Maybe.FromNullable((string) null).Should().Be(Maybe<string>.Nothing);
             }
 
             [Fact]
@@ -159,7 +159,7 @@ namespace Bearded.Utilities.Tests
             [Fact]
             public void ReturnsNothingOnNullableNoValue()
             {
-                Maybe.FromNullable((int?) null).Should().Be(Maybe.Nothing<int>());
+                Maybe.FromNullable((int?) null).Should().Be(Maybe<int>.Nothing);
             }
         
             [Fact]

--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Runtime.CompilerServices;
 
 namespace Bearded.Utilities
 {
@@ -14,19 +15,19 @@ namespace Bearded.Utilities
             this.value = value;
         }
 
-        internal static Maybe<T> Nothing() => new Maybe<T>();
+        public static Maybe<T> Nothing => default(Maybe<T>);
 
         internal static Maybe<T> Just(T value) => new Maybe<T>(value);
 
         public T ValueOrDefault(T @default) => hasValue ? value : @default;
 
         public Maybe<TOut> Select<TOut>(Func<T, TOut> selector) =>
-            hasValue ? Maybe.Just(selector(value)) : Maybe.Nothing<TOut>();
+            hasValue ? Maybe.Just(selector(value)) : Maybe<TOut>.Nothing;
 
         public Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector) =>
-            hasValue ? selector(value) : Maybe.Nothing<TOut>();
+            hasValue ? selector(value) : Maybe<TOut>.Nothing;
 
-        public Maybe<T> Where(Func<T, bool> predicate) => hasValue && predicate(value) ? this : Nothing();
+        public Maybe<T> Where(Func<T, bool> predicate) => hasValue && predicate(value) ? this : Nothing;
 
         public void Match(Action<T> onValue, Action onNothing)
         {
@@ -48,18 +49,25 @@ namespace Bearded.Utilities
         public override int GetHashCode() => hasValue ? EqualityComparer<T>.Default.GetHashCode(value) : 0;
 
         public override string ToString() => hasValue ? $"just {value}" : "nothing";
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Maybe<T>(Nothing _) => Nothing;
     }
 
     public static class Maybe
     {
         public static Maybe<T> FromNullable<T>(T value) where T : class =>
-            value == null ? Maybe<T>.Nothing() : Maybe<T>.Just(value);
+            value == null ? Nothing : Maybe<T>.Just(value);
 
         public static Maybe<T> FromNullable<T>(T? value) where T : struct =>
-            value.HasValue ? Maybe<T>.Just(value.Value) : Maybe<T>.Nothing();
+            value.HasValue ? Maybe<T>.Just(value.Value) : Nothing;
 
         public static Maybe<T> Just<T>(T value) => Maybe<T>.Just(value);
 
-        public static Maybe<T> Nothing<T>() => Maybe<T>.Nothing();
+        public static Nothing Nothing => default(Nothing);
+    }
+
+    public struct Nothing
+    {
     }
 }


### PR DESCRIPTION
We can now:

```
Maybe.Nothing
```

which will cast itself to whatever Maybe type needed implicitly. Actual maybe values won't magically cast between different Ts, because that would be semantically wrong.

To avoid name collisions I had to move:
```
Maybe.Nothing<T>()
```
to
```
Maybe<T>.Nothing
```
which is the only bad thing about this as far as I can tell. I made it a property because I don't see why it should be a method.