### PR TITLE
Allow static using of Nothing Maybe

### DIFF
--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -51,7 +51,7 @@ namespace Bearded.Utilities
         public override string ToString() => hasValue ? $"just {value}" : "nothing";
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Maybe<T>(Nothing _) => Nothing;
+        public static implicit operator Maybe<T>(NothingMaybe _) => Nothing;
     }
 
     public static class Maybe
@@ -64,10 +64,10 @@ namespace Bearded.Utilities
 
         public static Maybe<T> Just<T>(T value) => Maybe<T>.Just(value);
 
-        public static Nothing Nothing => default(Nothing);
+        public static NothingMaybe Nothing => default(NothingMaybe);
     }
 
-    public struct Nothing
+    public struct NothingMaybe
     {
     }
 }


### PR DESCRIPTION
The type name conflicted with the property in `Maybe` when static using the type for nice `Just(value)` and `Nothing` expressions.

Since you should never actually need this type name I see no problem with renaming it.