### PR TITLE
Add reverse enumeration of deletable object list

### DIFF
--- a/Bearded.Utilities/Collections/DeletableObjectList.cs
+++ b/Bearded.Utilities/Collections/DeletableObjectList.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 
 namespace Bearded.Utilities.Collections
@@ -106,8 +107,18 @@ namespace Bearded.Utilities.Collections
 
         #region Enumeration
 
+        private IEnumerable<T> reversed;
+
+        /// <summary>
+        /// Returns an enumerable that allows for enumerating the collection backwards.
+        /// Items added during backwards enumeration will not be enumerated.
+        /// Unlike a call to Reverse(), this property works in constant time and upcoming items deleted
+        /// during backwards enumeration will be skipped.
+        /// </summary>
+        public IEnumerable<T> Reversed => reversed ?? (reversed = new ReverseEnumerable(this));
+
         /// <inheritdoc />
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator() => GetEnumerator();
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
 
         /// <inheritdoc />
         public IEnumerator<T> GetEnumerator() => new DeletableObjectListEnumerator<T>(this, list);
@@ -176,5 +187,18 @@ namespace Bearded.Utilities.Collections
 
         #endregion
 
+        sealed class ReverseEnumerable : IEnumerable<T>
+        {
+            private readonly DeletableObjectList<T> list;
+
+            public ReverseEnumerable(DeletableObjectList<T> list)
+            {
+                this.list = list;
+            }
+
+            IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+
+            public IEnumerator<T> GetEnumerator() => new ReversedDeletableObjectListEnumerator<T>(list, list.list);
+        }
     }
 }

--- a/Bearded.Utilities/Collections/ReversedDeletableObjectListEnumerator.cs
+++ b/Bearded.Utilities/Collections/ReversedDeletableObjectListEnumerator.cs
@@ -1,0 +1,62 @@
+using System.Collections.Generic;
+
+namespace Bearded.Utilities.Collections
+{
+    /// <summary>
+    /// Enumerator for deletable object list.
+    /// Kept internal to hide implementation.
+    /// </summary>
+    internal class ReversedDeletableObjectListEnumerator<T> : IEnumerator<T>
+        where T : class, IDeletable
+    {
+        private readonly DeletableObjectList<T> deletableObjectList;
+        private readonly List<T> list;
+        private int i;
+
+        object System.Collections.IEnumerator.Current => Current;
+        public T Current { get; private set; }
+
+        public ReversedDeletableObjectListEnumerator(DeletableObjectList<T> deletableObjectList, List<T> list)
+        {
+            this.deletableObjectList = deletableObjectList;
+            this.list = list;
+            i = list.Count;
+
+            deletableObjectList.RegisterEnumerator();
+        }
+
+        public void Dispose()
+        {
+            deletableObjectList.UnregisterEnumerator();
+        }
+
+        public bool MoveNext()
+        {
+            while (i > 0)
+            {
+                i--;
+
+                var item = list[i];
+
+                if (item == null)
+                    continue;
+
+                if (item.Deleted)
+                {
+                    deletableObjectList.ClearBackingArrayIndex(i);
+                }
+                else
+                {
+                    Current = item;
+                    return true;
+                }
+            }
+            return false;
+        }
+
+        public void Reset()
+        {
+            i = list.Count;
+        }
+    }
+}


### PR DESCRIPTION
## ✨ What's this?
This implements efficient reverse enumeration of a deletable object list. Items deleted during enumeration are still ignored, and the enumeration has constant time overhead, instead of linear (like Linq's Reverse() would be).

Most importantly, items added during enumeration are not enumerated this way, which is the key use case.

### 🔗 Relationships

Closes #62

## 🔍 Why do we want this?
Sometimes we don't want to enumerate items we add during enumeration until the next time. This allows for that (assuming we don't mind the inverted order of course).

## 🏗 How is it done?
I added a Reversed property that returns a special cached enumerable wrapper which can create a special enumerator implementing this behaviour.

### 💥 Breaking changes
None.

## 💡 Review hints
Mostly check that the new tests make sense. They are mostly adapted copies of the existing enumeration tests.