### PR TITLE
⬆ Enable C#8 language features and nullability warnings

### DIFF
--- a/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
+++ b/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>warnings</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
+++ b/Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>warnings</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
+++ b/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netcoreapp2.2</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>warnings</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/Bearded.Utilities.Tests/Collections/DeletableObjectListTests.cs
+++ b/Bearded.Utilities.Tests/Collections/DeletableObjectListTests.cs
@@ -18,13 +18,11 @@ namespace Bearded.Utilities.Tests.Collections
         private static readonly Func<EquivalencyAssertionOptions<TestDeletable>, EquivalencyAssertionOptions<TestDeletable>>
             withExactSameItems = o => o.WithStrictOrdering().ComparingByValue<TestDeletable>();
 
-        public static IEnumerable<object[]> PositiveCounts =>
-            new [] {1, 2, 3, 4, 5, 7, 10, 13, 37, 42, 1337}
-                .Select(i => new object[] { i });
-        
+        public static TheoryData<int> PositiveCounts => new TheoryData<int> {1, 2, 3, 4, 5, 7, 10, 13, 37, 42, 1337};
+
         private static List<TestDeletable> getDeletables(int itemsToAdd)
             => Enumerable.Range(0, itemsToAdd).Select(i => new TestDeletable()).ToList();
-        
+
         private static (DeletableObjectList<TestDeletable> List, List<TestDeletable> Items)
             createPopulatedList(int itemsToAdd)
         {
@@ -34,12 +32,12 @@ namespace Bearded.Utilities.Tests.Collections
                 list.Add(item);
             return (list, items);
         }
-        
+
         public class TestDeletable : IDeletable
         {
             public bool Deleted { get; set; }
         }
-        
+
         public class TheParameterlessConstructor
         {
             [Fact]
@@ -50,26 +48,26 @@ namespace Bearded.Utilities.Tests.Collections
                 list.Should().BeEmpty();
             }
         }
-        
+
         public class TheIntParameterConstructor
         {
             [Fact]
             public void CreatesEmptyListForZeroValue()
             {
                 var list = new DeletableObjectList<IDeletable>(0);
-                
+
                 list.Should().BeEmpty();
             }
-            
+
             [Theory]
             [MemberData(nameof(PositiveCounts), MemberType = typeof(DeletableObjectListTests))]
             public void CreatesEmptyListForPositiveValues(int count)
             {
                 var list = new DeletableObjectList<IDeletable>(count);
-                
+
                 list.Should().BeEmpty();
             }
-            
+
             [Theory]
             [MemberData(nameof(PositiveCounts), MemberType = typeof(DeletableObjectListTests))]
             public void ThrowsForNegativeValues(int count)
@@ -79,13 +77,20 @@ namespace Bearded.Utilities.Tests.Collections
                 createListWithNegativeValue.Should().Throw<ArgumentOutOfRangeException>();
             }
         }
-        
+
         public abstract class MethodThatDoesNotThrowsWhenEnumeratingTests
         {
             protected abstract void CallMethod(DeletableObjectList<TestDeletable> list);
 
-            public static IEnumerable<object[]> IndicesFromZeroToNineteen =
-                Enumerable.Range(0, 20).Select(i => new object[] {i});
+            public static TheoryData<int> IndicesFromZeroToNineteen = new TheoryData<int>();
+
+            static MethodThatDoesNotThrowsWhenEnumeratingTests()
+            {
+                foreach (var i in Enumerable.Range(0, 20))
+                {
+                    IndicesFromZeroToNineteen.Add(i);
+                }
+            }
 
             [Theory]
             [MemberData(nameof(IndicesFromZeroToNineteen))]
@@ -105,13 +110,13 @@ namespace Bearded.Utilities.Tests.Collections
         {
             protected override void CallMethod(DeletableObjectList<TestDeletable> list)
                 => list.Add(new TestDeletable());
-            
+
             [Fact]
             public void AddsObjectToList()
             {
                 var list = new DeletableObjectList<TestDeletable>();
                 var deletable = new TestDeletable();
-                
+
                 list.Add(deletable);
 
                 list.Should().ContainSingle().Which.Should().Be(deletable);
@@ -136,7 +141,7 @@ namespace Bearded.Utilities.Tests.Collections
 
                 foreach (var item in items)
                     list.Add(item);
-                
+
                 list.Should().BeEquivalentTo(items, withExactSameItems);
             }
 
@@ -167,7 +172,7 @@ namespace Bearded.Utilities.Tests.Collections
 
             protected override void CallMethod(DeletableObjectList<TestDeletable> list)
                 => list.Remove(list.RandomElement(random));
-            
+
             [Fact]
             public void ReturnsFalseOnANewList()
             {
@@ -177,59 +182,59 @@ namespace Bearded.Utilities.Tests.Collections
 
                 returnValue.Should().BeFalse();
             }
-            
+
             [Fact]
             public void ReturnsFalseForUnknownElement()
             {
                 var (list, _) = createPopulatedList(1);
 
                 var returnValue = list.Remove(new TestDeletable());
-                
+
                 returnValue.Should().BeFalse();
             }
-            
+
             [Fact]
             public void ReturnsFalseForNull()
             {
                 var (list, _) = createPopulatedList(1);
 
                 var returnValue = list.Remove(null);
-                
+
                 returnValue.Should().BeFalse();
             }
-            
+
             [Fact]
             public void ReturnsTrueForKnownItem()
             {
                 var (list, items) = createPopulatedList(1);
 
                 var returnValue = list.Remove(items[0]);
-                
+
                 returnValue.Should().BeTrue();
             }
-            
+
             [Fact]
             public void ReturnsFalseForRepeatedCall()
             {
                 var (list, items) = createPopulatedList(1);
-               
+
                 list.Remove(items[0]);
                 var returnValue = list.Remove(items[0]);
-                
+
                 returnValue.Should().BeFalse();
             }
-            
+
             [Fact]
             public void ReturnsFalseForClearedList()
             {
                 var (list, items) = createPopulatedList(1);
                 list.Clear();
-               
+
                 var returnValue = list.Remove(items[0]);
-                
+
                 returnValue.Should().BeFalse();
             }
-            
+
             [Theory]
             [MemberData(nameof(PositiveCounts), MemberType = typeof(DeletableObjectListTests))]
             public void CanRemoveMultipleItems(int itemsToAdd)
@@ -272,7 +277,7 @@ namespace Bearded.Utilities.Tests.Collections
                     enumeratedItems.Add(item);
                     list.Remove(toRemove);
                 }
-                
+
                 enumeratedItems.Should().BeEquivalentTo(items.Take(10), withExactSameItems);
             }
         }
@@ -281,31 +286,31 @@ namespace Bearded.Utilities.Tests.Collections
         {
             protected override void CallMethod(DeletableObjectList<TestDeletable> list)
                 => list.Clear();
-            
+
             [Fact]
             public void DoesNotThrowForEmptyList()
             {
                 var list = new DeletableObjectList<TestDeletable>();
-                
+
                 list.Clear();
             }
-            
+
             [Theory]
             [MemberData(nameof(PositiveCounts), MemberType = typeof(DeletableObjectListTests))]
             public void ClearsAllItems(int itemsToAdd)
             {
                 var (list, _) = createPopulatedList(itemsToAdd);
-                
+
                 list.Clear();
 
                 list.Should().BeEmpty();
             }
         }
-        
+
         public abstract class NonMutatingMethodThatThrowsWhenEnumeratingTests
         {
             protected abstract void CallMethod(DeletableObjectList<TestDeletable> list);
-            
+
             [Fact]
             public void DoesNotThrowForEmptyList()
             {
@@ -313,13 +318,13 @@ namespace Bearded.Utilities.Tests.Collections
 
                 CallMethod(list);
             }
-            
+
             [Theory]
             [MemberData(nameof(PositiveCounts), MemberType = typeof(DeletableObjectListTests))]
             public void DoesNotRemoveItems(int itemsToAdd)
             {
                 var (list, items) = createPopulatedList(itemsToAdd);
-                
+
                 CallMethod(list);
 
                 list.Should().BeEquivalentTo(items, withExactSameItems);
@@ -330,22 +335,22 @@ namespace Bearded.Utilities.Tests.Collections
             {
                 var list = new DeletableObjectList<TestDeletable>();
                 _ = list.GetEnumerator();
-                
+
                 Action callingWhileEnumerating = () => CallMethod(list);
 
                 callingWhileEnumerating.Should().Throw<InvalidOperationException>();
             }
-            
+
             [Fact]
             public void DoesNotThrowAfterDisposingEnumerator()
             {
                 var list = new DeletableObjectList<TestDeletable>();
                 var enumerator = list.GetEnumerator();
                 enumerator.Dispose();
-                
+
                 CallMethod(list);
             }
-            
+
             [Fact]
             public void ThrowsIfAtLeastOneEnumeratorIsNotDisposed()
             {
@@ -357,12 +362,12 @@ namespace Bearded.Utilities.Tests.Collections
                 {
                     enumerator.Dispose();
                 }
-                
+
                 Action callingWhileEnumerating = () => CallMethod(list);
 
                 callingWhileEnumerating.Should().Throw<InvalidOperationException>();
             }
-            
+
             [Fact]
             public void DoesNotThrowIfAllEnumeratorsAreDisposed()
             {
@@ -373,7 +378,7 @@ namespace Bearded.Utilities.Tests.Collections
                 {
                     enumerator.Dispose();
                 }
-                
+
                 CallMethod(list);
             }
         }
@@ -382,7 +387,7 @@ namespace Bearded.Utilities.Tests.Collections
         {
             protected override void CallMethod(DeletableObjectList<TestDeletable> list) => list.TrimExcess();
         }
-        
+
         public class TheForceCompactMethod : NonMutatingMethodThatThrowsWhenEnumeratingTests
         {
             protected override void CallMethod(DeletableObjectList<TestDeletable> list) => list.ForceCompact();
@@ -426,13 +431,13 @@ namespace Bearded.Utilities.Tests.Collections
             {
                 var (list, items) = createPopulatedList(20);
                 var enumeratedItems = new List<TestDeletable>();
-                
+
                 foreach (var item in list)
                 {
                     enumeratedItems.Add(item);
                     list.First().Deleted = true;
                 }
-                
+
                 enumeratedItems.Should().BeEquivalentTo(items, withExactSameItems);
                 list.Should().BeEmpty();
             }
@@ -448,10 +453,10 @@ namespace Bearded.Utilities.Tests.Collections
                 enumerator.MoveNext();
                 enumerator.MoveNext();
                 enumerator.MoveNext();
-                
+
                 list.Remove(items[0]);
                 items[1].Deleted = true;
-                
+
                 enumerator.Reset();
 
                 while (enumerator.MoveNext())
@@ -483,17 +488,17 @@ namespace Bearded.Utilities.Tests.Collections
 
                 list.ApproximateCount.Should().Be(0);
             }
-            
+
             [Fact]
             public void IsZeroForClearedList()
             {
                 var (list, _) = createPopulatedList(10);
-                
+
                 list.Clear();
-                
+
                 list.ApproximateCount.Should().Be(0);
             }
-            
+
             [Property]
             public void IsAccurateWhenAddingAndRemoving(PositiveInt itemsToAdd, int randomSeed)
             {
@@ -506,14 +511,14 @@ namespace Bearded.Utilities.Tests.Collections
                     list.Add(new TestDeletable());
                     list.ApproximateCount.Should().Be(i);
                 }
-                
+
                 foreach (var i in Enumerable.Range(1, itemCount))
                 {
                     list.Remove(list.RandomElement(random));
                     list.ApproximateCount.Should().Be(itemCount - i);
                 }
             }
-            
+
             [Property]
             public void IsAccurateAfterEnumerating(PositiveInt itemsToAdd, int randomSeed)
             {
@@ -523,7 +528,7 @@ namespace Bearded.Utilities.Tests.Collections
                 items.RandomElement(random).Deleted = true;
 
                 _ = list.Count();
-                
+
                 list.ApproximateCount.Should().Be(itemCount - 1);
             }
         }

--- a/Bearded.Utilities.Tests/Collections/DeletableObjectListTests.cs
+++ b/Bearded.Utilities.Tests/Collections/DeletableObjectListTests.cs
@@ -82,13 +82,16 @@ namespace Bearded.Utilities.Tests.Collections
         {
             protected abstract void CallMethod(DeletableObjectList<TestDeletable> list);
 
-            public static TheoryData<int> IndicesFromZeroToNineteen = new TheoryData<int>();
-
-            static MethodThatDoesNotThrowsWhenEnumeratingTests()
+            public static TheoryData<int> IndicesFromZeroToNineteen
             {
-                foreach (var i in Enumerable.Range(0, 20))
+                get
                 {
-                    IndicesFromZeroToNineteen.Add(i);
+                    var data = new TheoryData<int>();
+                    foreach (var i in Enumerable.Range(0, 20))
+                    {
+                        data.Add(i);
+                    }
+                    return data;
                 }
             }
 

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -1,6 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>net462;netstandard2.0</TargetFrameworks>
+    <LangVersion>8</LangVersion>
+    <Nullable>warnings</Nullable>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTK" Version="2.0.0" />

--- a/Bearded.Utilities/Collections/StaticPriorityQueue.cs
+++ b/Bearded.Utilities/Collections/StaticPriorityQueue.cs
@@ -183,7 +183,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="i">The index of the element to be removed.</param>
         protected virtual void reset(int i)
         {
-            this.data[i] = default(KeyValuePair<TPriority, TValue>);
+            this.data[i] = default;
         }
         #endregion
 

--- a/Bearded.Utilities/Core/AsyncAtomicUpdating.cs
+++ b/Bearded.Utilities/Core/AsyncAtomicUpdating.cs
@@ -25,7 +25,7 @@
             }
         }
 
-        public void UpdateToDefault() => UpdateTo(default(T));
+        public void UpdateToDefault() => UpdateTo(default);
         
         public void UpdateTo(T state)
         {

--- a/Bearded.Utilities/Core/Id.cs
+++ b/Bearded.Utilities/Core/Id.cs
@@ -4,7 +4,7 @@ using System.Runtime.InteropServices;
 namespace Bearded.Utilities
 {
     [StructLayout(LayoutKind.Sequential, Pack = 1)]
-    public struct Id<T> : IEquatable<Id<T>>
+    public readonly struct Id<T> : IEquatable<Id<T>>
     {
         public int Value { get; }
 

--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -4,7 +4,7 @@ using System.Runtime.CompilerServices;
 
 namespace Bearded.Utilities
 {
-    public struct Maybe<T> : IEquatable<Maybe<T>>
+    public readonly struct Maybe<T> : IEquatable<Maybe<T>>
     {
         private readonly bool hasValue;
         private readonly T value;
@@ -15,7 +15,7 @@ namespace Bearded.Utilities
             this.value = value;
         }
 
-        public static Maybe<T> Nothing => default(Maybe<T>);
+        public static Maybe<T> Nothing => default;
 
         internal static Maybe<T> Just(T value) => new Maybe<T>(value);
 
@@ -75,10 +75,10 @@ namespace Bearded.Utilities
 
         public static Maybe<T> Just<T>(T value) => Maybe<T>.Just(value);
 
-        public static NothingMaybe Nothing => default(NothingMaybe);
+        public static NothingMaybe Nothing => default;
     }
 
-    public struct NothingMaybe
+    public readonly struct NothingMaybe
     {
     }
 }

--- a/Bearded.Utilities/Core/Void.cs
+++ b/Bearded.Utilities/Core/Void.cs
@@ -2,7 +2,7 @@
 
 namespace Bearded.Utilities
 {
-    public struct Void : IComparable<Void>, IEquatable<Void>
+    public readonly struct Void : IComparable<Void>, IEquatable<Void>
     {
         // Behold its power http://xkcd.com/1486/
 

--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.Geometry
     /// <summary>
     /// A typesafe representation of a signed angle.
     /// </summary>
-    public struct Angle : IEquatable<Angle>, IFormattable
+    public readonly struct Angle : IEquatable<Angle>, IFormattable
     {
         private readonly float radians;
 

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.Geometry
     /// <summary>
     /// A typesafe representation of a direction in two dimensional space.
     /// </summary>
-    public struct Direction2 : IEquatable<Direction2>, IFormattable
+    public readonly struct Direction2 : IEquatable<Direction2>, IFormattable
     {
         private const float fromRadians = uint.MaxValue / Mathf.TwoPi;
         private const float toRadians = Mathf.TwoPi / uint.MaxValue;

--- a/Bearded.Utilities/Geometry/PolarPosition.cs
+++ b/Bearded.Utilities/Geometry/PolarPosition.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.Geometry
     /// <summary>
     /// Represents a position in two-dimensional space using polar coordinates.
     /// </summary>
-    public struct PolarPosition : IEquatable<PolarPosition>, IFormattable
+    public readonly struct PolarPosition : IEquatable<PolarPosition>, IFormattable
     {
         #region Properties
         /// <summary>

--- a/Bearded.Utilities/Geometry/Rectangle.cs
+++ b/Bearded.Utilities/Geometry/Rectangle.cs
@@ -9,7 +9,7 @@ namespace Bearded.Utilities.Geometry
     /// All properties assume the x axis pointing right and the y axis pointing down.
     /// Negative width or height rectangles are not allowed, and the constructor will throw with those values.
     /// </summary>
-    public struct Rectangle : IEquatable<Rectangle>, IFormattable
+    public readonly struct Rectangle : IEquatable<Rectangle>, IFormattable
     {
         public float Left { get; }
         public float Top { get; }

--- a/Bearded.Utilities/IO/Logger.cs
+++ b/Bearded.Utilities/IO/Logger.cs
@@ -76,7 +76,7 @@ namespace Bearded.Utilities.IO
             Trace = 5,
         }
 
-        public struct Entry : IEquatable<Entry>
+        public readonly struct Entry : IEquatable<Entry>
         {
             public string Text { get; }
 

--- a/Bearded.Utilities/Input/InputManager.Actions.Gamepad.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Gamepad.cs
@@ -11,12 +11,12 @@ namespace Bearded.Utilities.Input
 
     partial class InputManager
     {
-        public partial struct ActionConstructor
+        public readonly partial struct ActionConstructor
         {
             public GamepadsActions Gamepad => new GamepadsActions(manager);
         }
 
-        public struct GamepadsActions
+        public readonly struct GamepadsActions
         {
             private readonly InputManager manager;
 
@@ -60,7 +60,7 @@ namespace Bearded.Utilities.Input
             }
         }
 
-        public struct GamepadActions
+        public readonly struct GamepadActions
         {
             private readonly InputManager manager;
             private readonly int padId;
@@ -100,7 +100,7 @@ namespace Bearded.Utilities.Input
             }
         }
 
-        public struct GamepadButtonActions
+        public readonly struct GamepadButtonActions
         {
             private readonly InputManager manager;
             private readonly int padId;
@@ -188,7 +188,7 @@ namespace Bearded.Utilities.Input
                 };
         }
 
-        public struct GamepadAxisActions
+        public readonly struct GamepadAxisActions
         {
             private readonly InputManager manager;
             private readonly int padId;

--- a/Bearded.Utilities/Input/InputManager.Actions.Gamepad.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Gamepad.cs
@@ -78,7 +78,7 @@ namespace Bearded.Utilities.Input
                 => padId >= 0 && padId < manager.GamePads.Count
                    && manager.GamePads[padId].State.Current.IsConnected;
 
-            public IEnumerable<IAction> All => Buttons.All.Concat<IAction>(Axes.All);
+            public IEnumerable<IAction> All => Buttons.All.Concat(Axes.All);
 
             public IAction FromButtonName(string value)
                 => TryParseButtonName(value, out var action)

--- a/Bearded.Utilities/Input/InputManager.Actions.Keyboard.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Keyboard.cs
@@ -8,12 +8,12 @@ namespace Bearded.Utilities.Input
 {
     partial class InputManager
     {
-        public partial struct ActionConstructor
+        public readonly partial struct ActionConstructor
         {
             public KeyboardActions Keyboard => new KeyboardActions(manager);
         }
 
-        public struct KeyboardActions
+        public readonly struct KeyboardActions
         {
             private readonly InputManager manager;
 

--- a/Bearded.Utilities/Input/InputManager.Actions.Mouse.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Mouse.cs
@@ -8,12 +8,12 @@ namespace Bearded.Utilities.Input
 {
     partial class InputManager
     {
-        public partial struct ActionConstructor
+        public readonly partial struct ActionConstructor
         {
             public MouseActions Mouse => new MouseActions(manager);
         }
 
-        public struct MouseActions
+        public readonly struct MouseActions
         {
             private readonly InputManager manager;
 

--- a/Bearded.Utilities/Input/InputManager.Actions.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.cs
@@ -4,7 +4,7 @@
     {
         public ActionConstructor Actions => new ActionConstructor(this);
 
-        public partial struct ActionConstructor
+        public readonly partial struct ActionConstructor
         {
             private readonly InputManager manager;
             

--- a/Bearded.Utilities/Linq/Extensions.cs
+++ b/Bearded.Utilities/Linq/Extensions.cs
@@ -161,7 +161,7 @@ namespace Bearded.Utilities.Linq
                 return true;
             }
 
-            result = default(TNewValue);
+            result = default;
             return false;
         }
 

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a 2d directed acceleration vector.
     /// </summary>
-    public struct Acceleration2 : IEquatable<Acceleration2>, IFormattable
+    public readonly struct Acceleration2 : IEquatable<Acceleration2>, IFormattable
     {
         private readonly Vector2 value;
 

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a 2d directed difference vector.
     /// </summary>
-    public struct Difference2 : IEquatable<Difference2>, IFormattable
+    public readonly struct Difference2 : IEquatable<Difference2>, IFormattable
     {
         private readonly Vector2 value;
 

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of an absolute 2d position vector.
     /// </summary>
-    public struct Position2 : IEquatable<Position2>, IFormattable
+    public readonly struct Position2 : IEquatable<Position2>, IFormattable
     {
         private readonly Vector2 value;
 

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a 2d directed velocity vector.
     /// </summary>
-    public struct Velocity2 : IEquatable<Velocity2>, IFormattable
+    public readonly struct Velocity2 : IEquatable<Velocity2>, IFormattable
     {
         private readonly Vector2 value;
 

--- a/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a 3d directed acceleration vector.
     /// </summary>
-    public struct Acceleration3 : IEquatable<Acceleration3>, IFormattable
+    public readonly struct Acceleration3 : IEquatable<Acceleration3>, IFormattable
     {
         private readonly Vector3 value;
 

--- a/Bearded.Utilities/SpaceTime/3d/Difference3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Difference3.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a 3d directed difference vector.
     /// </summary>
-    public struct Difference3 : IEquatable<Difference3>, IFormattable
+    public readonly struct Difference3 : IEquatable<Difference3>, IFormattable
     {
         private readonly Vector3 value;
 

--- a/Bearded.Utilities/SpaceTime/3d/Position3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Position3.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of an absolute 3d position vector.
     /// </summary>
-    public struct Position3 : IEquatable<Position3>, IFormattable
+    public readonly struct Position3 : IEquatable<Position3>, IFormattable
     {
         private readonly Vector3 value;
 

--- a/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a 3d directed velocity vector.
     /// </summary>
-    public struct Velocity3 : IEquatable<Velocity3>, IFormattable
+    public readonly struct Velocity3 : IEquatable<Velocity3>, IFormattable
     {
         private readonly Vector3 value;
 

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// Represents a type-safe squared value, backed by a float.
     /// </summary>
     /// <typeparam name="T">The squared type.</typeparam>
-    public struct Squared<T> : IEquatable<Squared<T>>, IComparable<Squared<T>>, IFormattable
+    public readonly struct Squared<T> : IEquatable<Squared<T>>, IComparable<Squared<T>>, IFormattable
         where T : struct
     {
         private readonly float value;
@@ -20,7 +20,7 @@ namespace Bearded.Utilities.SpaceTime
         }
 
         /// <summary>
-        /// Creteas a new instance of the Squared type, from a given root value.
+        /// Creates a new instance of the Squared type, from a given root value.
         /// </summary>
         public static Squared<T> FromRoot(float root)
         {
@@ -28,7 +28,7 @@ namespace Bearded.Utilities.SpaceTime
         }
 
         /// <summary>
-        /// Creteas a new instance of the Squared type, from a given value.
+        /// Creates a new instance of the Squared type, from a given value.
         /// </summary>
         /// <exception cref="ArgumentOutOfRangeException">If value is negative.</exception>
         public static Squared<T> FromValue(float value)

--- a/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
@@ -5,9 +5,9 @@ using Bearded.Utilities.Geometry;
 namespace Bearded.Utilities.SpaceTime
 {
     /// <summary>
-    /// A type-safe representation of a signed ancular acceleration.
+    /// A type-safe representation of a signed angular acceleration.
     /// </summary>
-    public struct AngularAcceleration : IEquatable<AngularAcceleration>, IComparable<AngularAcceleration>, IFormattable
+    public readonly struct AngularAcceleration : IEquatable<AngularAcceleration>, IComparable<AngularAcceleration>, IFormattable
     {
         private readonly float value;
 

--- a/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
@@ -5,9 +5,9 @@ using Bearded.Utilities.Geometry;
 namespace Bearded.Utilities.SpaceTime
 {
     /// <summary>
-    /// A type-safe representation of a signed ancular velocity.
+    /// A type-safe representation of a signed angular velocity.
     /// </summary>
-    public struct AngularVelocity : IEquatable<AngularVelocity>, IComparable<AngularVelocity>, IFormattable
+    public readonly struct AngularVelocity : IEquatable<AngularVelocity>, IComparable<AngularVelocity>, IFormattable
     {
         private readonly float value;
 

--- a/Bearded.Utilities/SpaceTime/gravity/GravitationalConstant.cs
+++ b/Bearded.Utilities/SpaceTime/gravity/GravitationalConstant.cs
@@ -2,7 +2,7 @@
 
 namespace Bearded.Utilities.SpaceTime
 {
-    public struct GravitationalConstant
+    public readonly struct GravitationalConstant
     {
         private readonly float value;
 

--- a/Bearded.Utilities/SpaceTime/gravity/Mass.cs
+++ b/Bearded.Utilities/SpaceTime/gravity/Mass.cs
@@ -3,7 +3,7 @@ using System.Globalization;
 
 namespace Bearded.Utilities.SpaceTime
 {
-    public struct Mass : IEquatable<Mass>, IComparable<Mass>, IFormattable
+    public readonly struct Mass : IEquatable<Mass>, IComparable<Mass>, IFormattable
     {
         private readonly float value;
 

--- a/Bearded.Utilities/SpaceTime/time/Frequency.cs
+++ b/Bearded.Utilities/SpaceTime/time/Frequency.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a signed frequency.
     /// </summary>
-    public struct Frequency : IEquatable<Frequency>, IComparable<Frequency>, IFormattable
+    public readonly struct Frequency : IEquatable<Frequency>, IComparable<Frequency>, IFormattable
     {
         private readonly double value;
 

--- a/Bearded.Utilities/SpaceTime/time/Instant.cs
+++ b/Bearded.Utilities/SpaceTime/time/Instant.cs
@@ -6,7 +6,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of an absolute instant in time.
     /// </summary>
-    public struct Instant : IEquatable<Instant>, IComparable<Instant>, IFormattable
+    public readonly struct Instant : IEquatable<Instant>, IComparable<Instant>, IFormattable
     {
         private readonly double value;
 

--- a/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
+++ b/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of a signed timespan.
     /// </summary>
-    public struct TimeSpan : IEquatable<TimeSpan>, IComparable<TimeSpan>, IFormattable
+    public readonly struct TimeSpan : IEquatable<TimeSpan>, IComparable<TimeSpan>, IFormattable
     {
         private readonly double value;
 

--- a/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of an undirected signed acceleration.
     /// </summary>
-    public struct Acceleration : IEquatable<Acceleration>, IComparable<Acceleration>, IFormattable
+    public readonly struct Acceleration : IEquatable<Acceleration>, IComparable<Acceleration>, IFormattable
     {
         private readonly float value;
 

--- a/Bearded.Utilities/SpaceTime/undirected/Speed.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Speed.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of an undirected signed speed.
     /// </summary>
-    public struct Speed : IEquatable<Speed>, IComparable<Speed>, IFormattable
+    public readonly struct Speed : IEquatable<Speed>, IComparable<Speed>, IFormattable
     {
         private readonly float value;
 

--- a/Bearded.Utilities/SpaceTime/undirected/Unit.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Unit.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities.SpaceTime
     /// <summary>
     /// A type-safe representation of an undirected signed distance or length.
     /// </summary>
-    public struct Unit : IEquatable<Unit>, IComparable<Unit>, IFormattable
+    public readonly struct Unit : IEquatable<Unit>, IComparable<Unit>, IFormattable
     {
         private readonly float value;
 

--- a/Bearded.Utilities/Threading/ManualActionQueue.cs
+++ b/Bearded.Utilities/Threading/ManualActionQueue.cs
@@ -124,7 +124,7 @@ namespace Bearded.Utilities.Threading
         /// <param name="action">The function to run.</param>
         public T RunAndReturn<T>(Func<T> action)
         {
-            T ret = default(T);
+            T ret = default;
             this.RunAndAwait(() => ret = action());
             return ret;
         }

--- a/Bearded.Utilities/Tilemaps/Rectangular/Tile.cs
+++ b/Bearded.Utilities/Tilemaps/Rectangular/Tile.cs
@@ -7,7 +7,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
     /// Represents a reference to a specific tile of a rectangular tilemap.
     /// </summary>
     /// <typeparam name="TTileValue">The kind of data contained in the tilemap.</typeparam>
-    public struct Tile<TTileValue>
+    public readonly struct Tile<TTileValue>
         : IEquatable<Tile<TTileValue>>
     {
         private readonly Tilemap<TTileValue> tilemap;

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,7 +1,7 @@
 version: 0.2.0.{build}
 pull_requests:
   do_not_increment_build_number: true
-image: Visual Studio 2017
+image: Visual Studio 2019
 configuration: Release
 init:
 - ps: >-


### PR DESCRIPTION
## ✨ What's this?
This PR switches the language support for all projects to C# 8. It also enables warnings for nullable reference types. It does not enforce them yet, as several classes need cleanup beyond the scope of a single PR.

### 🔗 Relationships
See #184 for follow-up task of moving to full nullability enforcement.

## 🔍 Why do we want this?
C# 8 leads to nicer, more readable code. Nullable reference type enforcement discourages the use of null, which in turn improves code stability.

## 🏗 How is it done?
The project files are updated. The other changes were either simple search and replaces, or were done with IDE support.

The big manual change was the `DeletableObjectListTests` file. It used `IEnumerable<object[]>` for parameterised tests, but nullability doesn't like that. There is actually a typesafe way of passing in data using `TheoryData`, so I just switched to that instead.

### 💥 Breaking changes
None.

### 🔬 Why not another way?
N/A

### 🦋 Side effects
We may see our return types in the future be moved from non-nullable to nullable. However, we're not in a worse state now than we were before.

## 💡 Review hints
Each of the commits is a simple change (by design), or a search and replace, so reviewing commit by commit may be easier than reviewing all changes together.