### PR TITLE
🛰 Update build key

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -35,6 +35,6 @@ artifacts:
 deploy:
 - provider: NuGet
   api_key:
-    secure: BBDmgOZL5KQ5tvZRZ4Qv1YOElpfvpS1Mr1z8aUE6xpCRfhqxzTm6UeTKMrbR+xZV
+    secure: z/bGxDPu7X55VAj/RY2RjwveLwQHfKZT1crl/8izoGpwavWhGmenGmvD63YqmYJs
   on:
     branch: /^(develop|master)$/


### PR DESCRIPTION
## ✨ What's this?
Update build key for deploying to NuGet

## 🔍 Why do we want this?
Appveyor publishing is broken otherwise

## 🏗 How is it done?
Generated key, encrypted using AppVeyor secure tool.