### PR TITLE
🐛 Don't transform the mouse position twice

### DIFF
--- a/Bearded.Utilities/Input/InputManager.cs
+++ b/Bearded.Utilities/Input/InputManager.cs
@@ -50,8 +50,7 @@ namespace Bearded.Utilities.Input
                 mouseEvents.Update();
                 keyboardState.Update();
                 mouseState.Update();
-                MousePosition = nativeWindow.PointToClient(
-                    new Vector2i((int) mouseState.Current.X, (int) mouseState.Current.Y)).ToVector2();
+                MousePosition = mouseState.Current.Position;
             }
             else
             {


### PR DESCRIPTION
## ✨ What's this?
This PR fixes a problem introduced by a breaking change from upgrading OpenTK from 2 to 4 where the mouse position is now given in client coordinates, rather than screen coordinates.

## 🔍 Why do we want this?
This fixes a breaking change.

## 🏗 How is it done?
We used to do the transformation ourselves. That is now no longer needed, so this has been removed.

### 💥 Breaking changes
This reverts a previous breaking change. Any dependency on this broken change in this version will be broken by this fix.

### 🔬 Why not another way?
This is in line with the original library behaviour.

### 🦋 Side effects
There have been reports that the client coordinates in OpenTK may be offset by the window border size (e.g. the title bar in Windows). However, this cannot be tested without merging, since we don't have a test project.

## 💡 Review hints
N/A
