### PR TITLE
🐛 Fix a typo in keyboard events

### DIFF
--- a/Bearded.Utilities/Input/KeyboardEvents.cs
+++ b/Bearded.Utilities/Input/KeyboardEvents.cs
@@ -38,8 +38,7 @@ namespace Bearded.Utilities.Input
 
         private void onTextInput(TextInputEventArgs e)
         {
-            // FIXME: unicode may be represented by a string of more than one character
-            pressedCharacters.Add((char) e.Unicode);
+            pressedCharactersQueue.Enqueue((char) e.Unicode);
         }
 
         internal void Update()

--- a/Bearded.Utilities/Input/KeyboardEvents.cs
+++ b/Bearded.Utilities/Input/KeyboardEvents.cs
@@ -38,6 +38,7 @@ namespace Bearded.Utilities.Input
 
         private void onTextInput(TextInputEventArgs e)
         {
+            // FIXME: unicode may be represented by a string of more than one character
             pressedCharactersQueue.Enqueue((char) e.Unicode);
         }
 


### PR DESCRIPTION
## ✨ What's this?
Fix a typo that occurred when migrating the text input on the keyboard manager.

## 🔍 Why do we want this?
Typos are bad.

## 🏗 How is it done?
N/A

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
N/A

### 🦋 Side effects
N/A

## 💡 Review hints
N/A