### PR TITLE
🆙 Update OpenTK to 4.0 stable

### DIFF
--- a/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
+++ b/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>warnings</Nullable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="xunit" Version="2.4.1" />

--- a/Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
+++ b/Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>warnings</Nullable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/Bearded.Utilities.Tests/Algorithms/HungarianAlgorithmTests.cs
+++ b/Bearded.Utilities.Tests/Algorithms/HungarianAlgorithmTests.cs
@@ -2,7 +2,7 @@
 using Bearded.Utilities.Algorithms;
 using Bearded.Utilities.Tests.Generators;
 using FsCheck.Xunit;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 using Xunit;
 using static System.Math;
 

--- a/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
+++ b/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
@@ -1,8 +1,8 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netcoreapp2.2</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>warnings</Nullable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/Bearded.Utilities.Tests/SpaceTime/GravitationalConstantTests.cs
+++ b/Bearded.Utilities.Tests/SpaceTime/GravitationalConstantTests.cs
@@ -3,7 +3,7 @@ using Bearded.Utilities.SpaceTime;
 using Bearded.Utilities.Tests.Helpers;
 using FluentAssertions;
 using FsCheck.Xunit;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 using Xunit;
 
 namespace Bearded.Utilities.Tests.SpaceTime
@@ -64,7 +64,7 @@ namespace Bearded.Utilities.Tests.SpaceTime
                     .BeApproximatelyOrBothNaNOrInfinity(expectedAcceleration.Y);
             }
         }
-        
+
         public class TheAccelerationTowardsWithUnitMethod
         {
             [Property(Arbitrary = new []{typeof(LimitedRangeFloatGenerator)})]
@@ -116,7 +116,7 @@ namespace Bearded.Utilities.Tests.SpaceTime
                 var expectedAcceleration = gValue * massValue / distanceValue.Squared();
 
                 var acceleration = g.AccelerationAtDistance(mass, distance);
-                
+
                 acceleration.NumericValue.Should()
                     .BeApproximatelyOrBothNaNOrInfinity(expectedAcceleration);
             }

--- a/Bearded.Utilities/Algorithms/HungarianAlgorithm.cs
+++ b/Bearded.Utilities/Algorithms/HungarianAlgorithm.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Linq;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Algorithms
 {

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -1,13 +1,17 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net472;netstandard2.0</TargetFrameworks>
     <LangVersion>8</LangVersion>
     <Nullable>warnings</Nullable>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenToolkit.Graphics" Version="4.0.0-pre9.1" />
-    <PackageReference Include="OpenToolkit.Windowing.Common" Version="4.0.0-pre9.1" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.0.0" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.0.0" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.0.0" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
+  </ItemGroup>
+  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
+    <PackageReference Include="OpenTK.Windowing.Common" Version="4.0.0" />
   </ItemGroup>
 </Project>

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -5,9 +5,9 @@
     <TargetFramework>netcoreapp3.1</TargetFramework>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK.Mathematics" Version="4.0.0" />
-    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.0.0" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.0.0" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.0.2" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.0.2" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.0.2" />
     <PackageReference Include="System.Collections.Immutable" Version="1.5.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/Bearded.Utilities/Core/Interpolate.cs
+++ b/Bearded.Utilities/Core/Interpolate.cs
@@ -1,4 +1,4 @@
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities
 {

--- a/Bearded.Utilities/Core/MathExtensions.cs
+++ b/Bearded.Utilities/Core/MathExtensions.cs
@@ -1,5 +1,5 @@
 using System;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities
 {

--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/PolarPosition.cs
+++ b/Bearded.Utilities/Geometry/PolarPosition.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/Rectangle.cs
+++ b/Bearded.Utilities/Geometry/Rectangle.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/arcs/Arc2.cs
+++ b/Bearded.Utilities/Geometry/arcs/Arc2.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/arcs/Arc3.cs
+++ b/Bearded.Utilities/Geometry/arcs/Arc3.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/arcs/Bezier2nd2.cs
+++ b/Bearded.Utilities/Geometry/arcs/Bezier2nd2.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/arcs/Bezier2nd3.cs
+++ b/Bearded.Utilities/Geometry/arcs/Bezier2nd3.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/arcs/Bezier3rd2.cs
+++ b/Bearded.Utilities/Geometry/arcs/Bezier3rd2.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Geometry/arcs/Bezier3rd3.cs
+++ b/Bearded.Utilities/Geometry/arcs/Bezier3rd3.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Mathematics;
+﻿using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.Geometry
 {

--- a/Bearded.Utilities/Input/Actions/KeyboardAction.cs
+++ b/Bearded.Utilities/Input/Actions/KeyboardAction.cs
@@ -1,13 +1,13 @@
-using OpenToolkit.Windowing.Common.Input;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Bearded.Utilities.Input.Actions
 {
     sealed class KeyboardAction : DigitalAction
     {
         private readonly InputManager inputManager;
-        private readonly Key key;
+        private readonly Keys key;
 
-        public KeyboardAction(InputManager inputManager, Key key)
+        public KeyboardAction(InputManager inputManager, Keys key)
         {
             this.inputManager = inputManager;
             this.key = key;

--- a/Bearded.Utilities/Input/Actions/MouseAction.cs
+++ b/Bearded.Utilities/Input/Actions/MouseAction.cs
@@ -1,4 +1,4 @@
-﻿using OpenToolkit.Windowing.Common.Input;
+﻿using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Bearded.Utilities.Input.Actions
 {

--- a/Bearded.Utilities/Input/InputManager.Actions.Keyboard.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Keyboard.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Bearded.Utilities.Input.Actions;
-using OpenToolkit.Windowing.Common.Input;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Bearded.Utilities.Input
 {
@@ -27,11 +27,11 @@ namespace Bearded.Utilities.Input
                 get
                 {
                     var m = manager;
-                    return ((Key[])Enum.GetValues(typeof(Key))).Select(k => new KeyboardAction(m, k));
+                    return ((Keys[])Enum.GetValues(typeof(Keys))).Select(k => new KeyboardAction(m, k));
                 }
             }
 
-            public IAction FromKey(Key key) => new KeyboardAction(manager, key);
+            public IAction FromKey(Keys key) => new KeyboardAction(manager, key);
 
             public IAction FromString(string value)
                 => TryParse(value, out var action)
@@ -50,10 +50,10 @@ namespace Bearded.Utilities.Input
 
                 var keyName = value.Substring(9).Trim();
 
-                if (!Enum.TryParse(keyName, false, out Key key))
+                if (!Enum.TryParse(keyName, false, out Keys key))
                     return false;
 
-                if (key == Key.Unknown)
+                if (key == Keys.Unknown)
                     return false;
 
                 action = new KeyboardAction(manager, key);

--- a/Bearded.Utilities/Input/InputManager.Actions.Mouse.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Mouse.cs
@@ -2,7 +2,7 @@
 using System.Collections.Generic;
 using System.Linq;
 using Bearded.Utilities.Input.Actions;
-using OpenToolkit.Windowing.Common.Input;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Bearded.Utilities.Input
 {

--- a/Bearded.Utilities/Input/InputManager.cs
+++ b/Bearded.Utilities/Input/InputManager.cs
@@ -64,7 +64,7 @@ namespace Bearded.Utilities.Input
         public int DeltaScroll => Mathf.RoundToInt(DeltaScrollF);
         public float DeltaScrollF => mouseEvents.DeltaScrollF;
 
-        public bool MouseMoved => mouseState.Delta.LengthSquared > 0;
+        public bool MouseMoved => mouseState.Delta.LengthSquared != 0;
 
         public bool LeftMousePressed => IsMouseButtonPressed(MouseButton.Left);
         public bool LeftMouseHit => IsMouseButtonHit(MouseButton.Left);

--- a/Bearded.Utilities/Input/InputManager.cs
+++ b/Bearded.Utilities/Input/InputManager.cs
@@ -1,26 +1,28 @@
 ﻿using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
-using OpenToolkit.Mathematics;
-using OpenToolkit.Windowing.Common;
-using OpenToolkit.Windowing.Common.Input;
+using OpenTK.Mathematics;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
+using OpenTK.Windowing.GraphicsLibraryFramework;
 
 namespace Bearded.Utilities.Input
 {
     public sealed partial class InputManager
     {
-        private readonly INativeWindow nativeWindow;
         private readonly KeyboardEvents keyboardEvents;
         private readonly MouseEvents mouseEvents;
 
-        private readonly AsyncAtomicUpdating<KeyboardState> keyboardState = new AsyncAtomicUpdating<KeyboardState>();
-        private readonly AsyncAtomicUpdating<MouseState> mouseState = new AsyncAtomicUpdating<MouseState>();
+        private readonly KeyboardState keyboardState;
+        private readonly MouseState mouseState;
 
         public ReadOnlyCollection<GamePadStateManager> GamePads { get; }
 
-        public InputManager(INativeWindow nativeWindow)
+        public InputManager(NativeWindow nativeWindow)
         {
-            this.nativeWindow = nativeWindow;
+            keyboardState = nativeWindow.KeyboardState;
+            mouseState = nativeWindow.MouseState;
+
             keyboardEvents = new KeyboardEvents(nativeWindow);
             mouseEvents = new MouseEvents(nativeWindow);
 
@@ -33,9 +35,6 @@ namespace Bearded.Utilities.Input
 
         public void ProcessEventsAsync()
         {
-            keyboardState.SetLastKnownState(nativeWindow.KeyboardState);
-            mouseState.SetLastKnownState(nativeWindow.MouseState);
-
             foreach (var gamePad in GamePads)
             {
                 gamePad.ProcessEventsAsync();
@@ -48,13 +47,11 @@ namespace Bearded.Utilities.Input
             {
                 keyboardEvents.Update();
                 mouseEvents.Update();
-                keyboardState.Update();
-                mouseState.Update();
-                MousePosition = mouseState.Current.Position;
+                MousePosition = mouseState.Position;
             }
             else
             {
-                keyboardState.UpdateToDefault();
+                //keyboardState.UpdateToDefault();
             }
 
             foreach (var gamePad in GamePads)
@@ -67,8 +64,7 @@ namespace Bearded.Utilities.Input
         public int DeltaScroll => Mathf.RoundToInt(DeltaScrollF);
         public float DeltaScrollF => mouseEvents.DeltaScrollF;
 
-        public bool MouseMoved => mouseState.Current.X != mouseState.Previous.X
-                                  || mouseState.Current.Y != mouseState.Previous.Y;
+        public bool MouseMoved => mouseState.Delta.LengthSquared > 0;
 
         public bool LeftMousePressed => IsMouseButtonPressed(MouseButton.Left);
         public bool LeftMouseHit => IsMouseButtonHit(MouseButton.Left);
@@ -82,15 +78,18 @@ namespace Bearded.Utilities.Input
         public bool MiddleMouseHit => IsMouseButtonHit(MouseButton.Middle);
         public bool MiddleMouseReleased => IsMouseButtonReleased(MouseButton.Middle);
 
-        public bool IsMouseButtonPressed(MouseButton button) => mouseState.Current[button];
-        public bool IsMouseButtonHit(MouseButton button) => mouseState.Current[button] && !mouseState.Previous[button];
-        public bool IsMouseButtonReleased(MouseButton button) => !mouseState.Current[button] && mouseState.Previous[button];
+        public bool IsMouseButtonPressed(MouseButton button) => mouseState.IsButtonDown(button);
+        public bool IsMouseButtonHit(MouseButton button) =>
+            IsMouseButtonPressed(button) && !mouseState.WasButtonDown(button);
+        public bool IsMouseButtonReleased(MouseButton button) =>
+            !IsMouseButtonPressed(button) && mouseState.WasButtonDown(button);
 
-        public bool IsKeyPressed(Key k) => keyboardState.Current.IsKeyDown(k);
-        public bool IsKeyHit(Key k) => IsKeyPressed(k) && keyboardState.Previous.IsKeyUp(k);
-        public bool IsKeyReleased(Key k) => !IsKeyPressed(k) && keyboardState.Previous.IsKeyDown(k);
+        public bool IsKeyPressed(Keys k) => keyboardState.IsKeyDown(k);
+        public bool IsKeyHit(Keys k) => IsKeyPressed(k) && !keyboardState.WasKeyDown(k);
+        public bool IsKeyReleased(Keys k) => !IsKeyPressed(k) && keyboardState.WasKeyDown(k);
 
-        public bool IsMouseInRectangle(System.Drawing.Rectangle rect) => rect.Contains((int) MousePosition.X, (int) MousePosition.Y);
+        public bool IsMouseInRectangle(System.Drawing.Rectangle rect) =>
+            rect.Contains((int) MousePosition.X, (int) MousePosition.Y);
 
         public IReadOnlyList<(KeyboardKeyEventArgs args, bool isPressed)> KeyEvents => keyboardEvents.KeyEvents;
         public IReadOnlyList<char> PressedCharacters => keyboardEvents.PressedCharacters;

--- a/Bearded.Utilities/Input/KeyboardEvents.cs
+++ b/Bearded.Utilities/Input/KeyboardEvents.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Concurrent;
 using System.Collections.Generic;
-using OpenToolkit.Windowing.Common;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
 
 namespace Bearded.Utilities.Input
 {
@@ -16,7 +17,7 @@ namespace Bearded.Utilities.Input
         internal IReadOnlyList<(KeyboardKeyEventArgs, bool)> KeyEvents { get; }
         internal IReadOnlyList<char> PressedCharacters { get; }
 
-        internal KeyboardEvents(INativeWindow nativeWindow)
+        internal KeyboardEvents(NativeWindow nativeWindow)
         {
             nativeWindow.KeyDown += onKeyDown;
             nativeWindow.KeyUp += onKeyUp;

--- a/Bearded.Utilities/Input/MouseEvents.cs
+++ b/Bearded.Utilities/Input/MouseEvents.cs
@@ -1,4 +1,5 @@
-using OpenToolkit.Windowing.Common;
+using OpenTK.Windowing.Common;
+using OpenTK.Windowing.Desktop;
 
 namespace Bearded.Utilities.Input
 {
@@ -8,7 +9,7 @@ namespace Bearded.Utilities.Input
 
         internal float DeltaScrollF { get; private set; }
 
-        internal MouseEvents(INativeWindow nativeWindow)
+        internal MouseEvents(NativeWindow nativeWindow)
         {
             nativeWindow.MouseWheel += onMouseWheel;
         }

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bearded.Utilities.Geometry;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bearded.Utilities.Geometry;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -1,6 +1,6 @@
 ﻿using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bearded.Utilities.Geometry;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/3d/Difference3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Difference3.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/3d/Position3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Position3.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
@@ -1,6 +1,6 @@
 using System;
 using System.Globalization;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bearded.Utilities.Geometry;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/undirected/Speed.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Speed.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bearded.Utilities.Geometry;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {

--- a/Bearded.Utilities/SpaceTime/undirected/Unit.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Unit.cs
@@ -1,7 +1,7 @@
 ﻿using System;
 using System.Globalization;
 using Bearded.Utilities.Geometry;
-using OpenToolkit.Mathematics;
+using OpenTK.Mathematics;
 
 namespace Bearded.Utilities.SpaceTime
 {


### PR DESCRIPTION
## ✨ What's this?
Updates the library to use the stable version of OpenTK. Future changes to the OpenTK API should be backwards compatible.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
Several bugfixes have been added to the OpenTK library, and the public interface is now considered stable.

## 🏗 How is it done?
Updated all the references to OpenTK 4.

### 💥 Breaking changes
* The target library has been updated to `netcoreapp3.1`. This is what OpenTK uses, and sadly it isn't very happy if we use a lower version.
* `KeyboardState` and `MouseState` are now classes in OpenTK, keeping the last state as well. Not too happy about it, but I think our input code needs an update anyway.

### 🔬 Why not another way?
N/A

### 🦋 Side effects
N/A

## 💡 Review hints
N/A