### PR TITLE
✨ Implement Result monad

### DIFF
--- a/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
+++ b/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
@@ -5,6 +5,7 @@
     <Nullable>warnings</Nullable>
   </PropertyGroup>
   <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.abstractions" Version="2.0.3" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />

--- a/Bearded.Utilities.Testing.Tests/Monads/ResultAssertionsTests.cs
+++ b/Bearded.Utilities.Testing.Tests/Monads/ResultAssertionsTests.cs
@@ -1,0 +1,244 @@
+using System;
+using Bearded.Utilities.Monads;
+using Bearded.Utilities.Testing.Monads;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Bearded.Utilities.Testing.Tests.Monads
+{
+    public sealed class ResultAssertionsTests
+    {
+        public sealed class BeSuccess
+        {
+            [Fact]
+            public void SucceedsWhenSuccess()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeSuccess();
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void FailsWhenFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeSuccess();
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void ReturnsAndConstraintThatSucceedsAsExpected()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeSuccess().And.Should().NotBeNull();
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void ReturnsAndConstraintThatFailsAsExpected()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeSuccess().And.Should().BeNull();
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void FailsWhenFailureEvenIfAndConstraintSucceeds()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeSuccess().And.Should().NotBeNull();
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void ReturnsWhichConstraintThatSucceedsAsExpected()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeSuccess().Which.Should().Be(100);
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void ReturnsWhichConstraintThatFailsAsExpected()
+            {
+                var result = Result.Success<int, string>(200);
+
+                Action assertion = () => result.Should().BeSuccess().Which.Should().Be(100);
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void FailsWhenFailureEvenIfWhichConstraintSucceeds()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeSuccess().Which.Should().Be(100);
+
+                assertion.Should().Throw<XunitException>();
+            }
+        }
+
+        public sealed class BeSuccessWithResult
+        {
+            [Fact]
+            public void SucceedsWhenSuccessWithSameResult()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeSuccessWithResult(100);
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void FailsWhenSuccessWithDifferentResult()
+            {
+                var result = Result.Success<int, string>(200);
+
+                Action assertion = () => result.Should().BeSuccessWithResult(100);
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void FailsWhenFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeSuccessWithResult(100);
+
+                assertion.Should().Throw<XunitException>();
+            }
+        }
+
+        public sealed class BeFailure
+        {
+            [Fact]
+            public void SucceedsWhenFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeFailure();
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void FailsWhenSuccess()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeFailure();
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void ReturnsAndConstraintThatSucceedsAsExpected()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeFailure().And.Should().NotBeNull();
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void ReturnsAndConstraintThatFailsAsExpected()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeFailure().And.Should().BeNull();
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void FailsWhenSuccessEvenIfAndConstraintSucceeds()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeFailure().And.Should().NotBeNull();
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void ReturnsWhichConstraintThatSucceedsAsExpected()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeFailure().Which.Should().Be("something went wrong");
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void ReturnsWhichConstraintThatFailsAsExpected()
+            {
+                var result = Result.Failure<int, string>("something else went wrong");
+
+                Action assertion = () => result.Should().BeFailure().Which.Should().Be("something went wrong");
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void FailsWhenSuccessEvenIfWhichConstraintSucceeds()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeFailure().Which.Should().Be("something went wrong");
+
+                assertion.Should().Throw<XunitException>();
+            }
+        }
+
+        public sealed class BeFailureWithError
+        {
+            [Fact]
+            public void SucceedsWhenFailureWithSameError()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.Should().BeFailureWithError("something went wrong");
+
+                assertion.Should().NotThrow();
+            }
+
+            [Fact]
+            public void FailsWhenFailureWithDifferentError()
+            {
+                var result = Result.Failure<int, string>("something else went wrong");
+
+                Action assertion = () => result.Should().BeFailureWithError("something went wrong");
+
+                assertion.Should().Throw<XunitException>();
+            }
+
+            [Fact]
+            public void FailsWhenSuccess()
+            {
+                var result = Result.Success<int, string>(100);
+
+                Action assertion = () => result.Should().BeFailureWithError("something went wrong");
+
+                assertion.Should().Throw<XunitException>();
+            }
+        }
+    }
+}

--- a/Bearded.Utilities.Testing/Monads/ResultAssertions.cs
+++ b/Bearded.Utilities.Testing/Monads/ResultAssertions.cs
@@ -1,0 +1,70 @@
+using Bearded.Utilities.Monads;
+using FluentAssertions;
+using FluentAssertions.Execution;
+
+namespace Bearded.Utilities.Testing.Monads
+{
+    public sealed class ResultAssertions<TResult, TError>
+    {
+        private readonly Result<TResult, TError> subject;
+
+        public ResultAssertions(Result<TResult, TError> subject)
+        {
+            this.subject = subject;
+        }
+
+        [CustomAssertion]
+        public void BeSuccessWithResult(TResult result, string because = "", params object[] becauseArgs)
+        {
+            BeSuccess().Which.Should().Be(result, because, becauseArgs);
+        }
+
+        [CustomAssertion]
+        public AndWhichConstraint<ResultAssertions<TResult, TError>, TResult> BeSuccess(
+            string because = "", params object[] becauseArgs)
+        {
+            var onResultCalled = false;
+            var matched = default(TResult);
+
+            subject.Match(actual =>
+            {
+                onResultCalled = true;
+                matched = actual;
+            });
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(onResultCalled)
+                .FailWith("Expected result to be successful, but was not.");
+
+            return new AndWhichConstraint<ResultAssertions<TResult, TError>, TResult>(this, matched);
+        }
+
+        [CustomAssertion]
+        public void BeFailureWithError(TError error, string because = "", params object[] becauseArgs)
+        {
+            BeFailure().Which.Should().Be(error, because, becauseArgs);
+        }
+
+        [CustomAssertion]
+        public AndWhichConstraint<ResultAssertions<TResult, TError>, TError> BeFailure(
+            string because = "", params object[] becauseArgs)
+        {
+            var onErrorCalled = false;
+            var matched = default(TError);
+
+            subject.Match(_ => {}, actual =>
+            {
+                onErrorCalled = true;
+                matched = actual;
+            });
+
+            Execute.Assertion
+                .BecauseOf(because, becauseArgs)
+                .ForCondition(onErrorCalled)
+                .FailWith("Expected result to be erroneous, but was not.");
+
+            return new AndWhichConstraint<ResultAssertions<TResult, TError>, TError>(this, matched);
+        }
+    }
+}

--- a/Bearded.Utilities.Testing/Monads/ResultExtensions.cs
+++ b/Bearded.Utilities.Testing/Monads/ResultExtensions.cs
@@ -1,0 +1,10 @@
+using Bearded.Utilities.Monads;
+
+namespace Bearded.Utilities.Testing.Monads
+{
+    public static class ResultExtensions
+    {
+        public static ResultAssertions<TResult, TError> Should<TResult, TError>(this Result<TResult, TError> subject) =>
+            new ResultAssertions<TResult, TError>(subject);
+    }
+}

--- a/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
+++ b/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
@@ -16,6 +16,7 @@
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1" />
   </ItemGroup>
   <ItemGroup>
+    <ProjectReference Include="..\Bearded.Utilities.Testing\Bearded.Utilities.Testing.csproj" />
     <ProjectReference Include="..\Bearded.Utilities\Bearded.Utilities.csproj" />
   </ItemGroup>
 </Project>

--- a/Bearded.Utilities.Tests/Monads/ResultTests.cs
+++ b/Bearded.Utilities.Tests/Monads/ResultTests.cs
@@ -71,14 +71,14 @@ namespace Bearded.Utilities.Tests.Monads
             }
         }
 
-        public sealed class ResultMaybe
+        public sealed class AsMaybe
         {
             [Fact]
             public void ReturnsNothingOnFailure()
             {
                 var result = Result.Failure<int, string>("something went wrong");
 
-                result.ResultMaybe().Should().BeNothing();
+                result.AsMaybe().Should().BeNothing();
             }
 
             [Fact]
@@ -86,7 +86,7 @@ namespace Bearded.Utilities.Tests.Monads
             {
                 var result = Result.Success<int, string>(200);
 
-                result.ResultMaybe().Should().BeJust(200);
+                result.AsMaybe().Should().BeJust(200);
             }
         }
 

--- a/Bearded.Utilities.Tests/Monads/ResultTests.cs
+++ b/Bearded.Utilities.Tests/Monads/ResultTests.cs
@@ -1,5 +1,6 @@
 using System;
 using Bearded.Utilities.Monads;
+using Bearded.Utilities.Testing;
 using FluentAssertions;
 using Xunit;
 using Xunit.Sdk;
@@ -67,6 +68,25 @@ namespace Bearded.Utilities.Tests.Monads
                 var result = Result.Success<int, string>(200);
 
                 result.ResultOrThrow(_ => new ApplicationException()).Should().Be(200);
+            }
+        }
+
+        public sealed class ResultMaybe
+        {
+            [Fact]
+            public void ReturnsNothingOnFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                result.ResultMaybe().Should().BeNothing();
+            }
+
+            [Fact]
+            public void ReturnsJustResultOnSuccess()
+            {
+                var result = Result.Success<int, string>(200);
+
+                result.ResultMaybe().Should().BeJust(200);
             }
         }
 

--- a/Bearded.Utilities.Tests/Monads/ResultTests.cs
+++ b/Bearded.Utilities.Tests/Monads/ResultTests.cs
@@ -1,0 +1,224 @@
+using System;
+using Bearded.Utilities.Monads;
+using FluentAssertions;
+using Xunit;
+using Xunit.Sdk;
+
+namespace Bearded.Utilities.Tests.Monads
+{
+    public sealed class ResultTests
+    {
+        public sealed class ResultOrDefault
+        {
+            public sealed class WithEagerDefault
+            {
+                [Fact]
+                public void ReturnsDefaultOnFailure()
+                {
+                    var result = Result.Failure<int, string>("something went wrong");
+
+                    result.ResultOrDefault(100).Should().Be(100);
+                }
+
+                [Fact]
+                public void ReturnsResultOnSuccess()
+                {
+                    var result = Result.Success<int, string>(200);
+
+                    result.ResultOrDefault(100).Should().Be(200);
+                }
+            }
+
+            public sealed class WithLazyDefault
+            {
+                [Fact]
+                public void ReturnsDefaultOnFailure()
+                {
+                    var result = Result.Failure<int, string>("something went wrong");
+
+                    result.ResultOrDefault(() => 100).Should().Be(100);
+                }
+
+                [Fact]
+                public void ReturnsResultOnSuccess()
+                {
+                    var result = Result.Success<int, string>(200);
+
+                    result.ResultOrDefault(() => 100).Should().Be(200);
+                }
+            }
+        }
+
+        public sealed class ResultOrThrow
+        {
+            [Fact]
+            public void TrowsOnFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                Action assertion = () => result.ResultOrThrow(_ => new ApplicationException());
+
+                assertion.Should().Throw<ApplicationException>();
+            }
+
+            [Fact]
+            public void ReturnsResultOnSuccess()
+            {
+                var result = Result.Success<int, string>(200);
+
+                result.ResultOrThrow(_ => new ApplicationException()).Should().Be(200);
+            }
+        }
+
+        public sealed class Select
+        {
+            [Fact]
+            public void MapsFailureToFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                result.Select(i => i * 2).Should().Be(Result.Failure<int, string>("something went wrong"));
+            }
+
+            [Fact]
+            public void MapsSuccessToSuccess()
+            {
+                var result = Result.Success<int, string>(100);
+
+                result.Select(i => i * 2).Should().Be(Result.Success<int, string>(200));
+            }
+        }
+
+        public sealed class SelectMany
+        {
+            [Fact]
+            public void MapsFailureToFailure()
+            {
+                var result = Result.Failure<int, string>("something went wrong");
+
+                result.SelectMany<int>(i => Result.Success(i * 2)).Should().Be(Result.Failure<int, string>("something went wrong"));
+            }
+
+            [Fact]
+            public void MapsSuccessToSuccess()
+            {
+                var result = Result.Success<int, string>(100);
+
+                result.SelectMany<int>(i => Result.Success(i * 2)).Should().Be(Result.Success<int, string>(200));
+            }
+
+            [Fact]
+            public void MapsSuccessToFailure()
+            {
+                var result = Result.Success<int, string>(100);
+
+                result.SelectMany<int>(i => Result.Failure("something went wrong"))
+                    .Should().Be(Result.Failure<int, string>("something went wrong"));
+            }
+        }
+
+        public sealed class Match
+        {
+            public sealed class WithOneParameter
+            {
+                [Fact]
+                public void DoesNotCallOnSuccessWithFailure()
+                {
+                    var result = Result.Failure<int, string>("something went wrong");
+
+                    result.Match(onSuccess: _ => throw new XunitException("Wrong method called"));
+                }
+
+                [Fact]
+                public void CallsOnSuccessWithResultOnSuccess()
+                {
+                    var result = Result.Success<int, string>(100);
+
+                    var isCalled = false;
+                    result.Match(
+                        onSuccess: r =>
+                        {
+                            r.Should().Be(100);
+                            isCalled = true;
+                        });
+
+                    isCalled.Should().BeTrue("onSuccess should have been called");
+                }
+            }
+
+            public sealed class WithTwoParameters
+            {
+                [Fact]
+                public void CallsOnFailureWithErrorOnFailure()
+                {
+                    var result = Result.Failure<int, string>("something went wrong");
+
+                    var isCalled = false;
+                    result.Match(
+                        onSuccess: r => throw new XunitException("Wrong method called"),
+                        onFailure: error =>
+                        {
+                            error.Should().Be("something went wrong");
+                            isCalled = true;
+                        });
+
+                    isCalled.Should().BeTrue("onFailure should have been called");
+                }
+
+                [Fact]
+                public void CallsOnSuccessWithResultOnSuccess()
+                {
+                    var result = Result.Success<int, string>(100);
+
+                    var isCalled = false;
+                    result.Match(
+                        onSuccess: r =>
+                        {
+                            r.Should().Be(100);
+                            isCalled = true;
+                        },
+                        onFailure: _ => throw new XunitException("Wrong method called"));
+
+                    isCalled.Should().BeTrue("onSuccess should have been called");
+                }
+            }
+
+            public sealed class Returning
+            {
+                [Fact]
+                public void CallsOnFailureWithErrorOnFailureAndReturnsItsValue()
+                {
+                    var result = Result.Failure<int, string>("something went wrong");
+                    const string expectedResult = "expected result";
+
+                    var actualResult = result.Match(
+                        onSuccess: _ => throw new XunitException("Wrong method called"),
+                        onFailure: error =>
+                        {
+                            error.Should().Be("something went wrong");
+                            return expectedResult;
+                        });
+
+                    actualResult.Should().Be(expectedResult, "onFailure should have been called");
+                }
+
+                [Fact]
+                public void CallsOnSuccessWithResultOnSuccessAndReturnsItsValue()
+                {
+                    var result = Result.Success<int, string>(100);
+                    const string expectedReturn = "expected result";
+
+                    var actualReturn = result.Match(
+                        onSuccess: r =>
+                        {
+                            r.Should().Be(100);
+                            return expectedReturn;
+                        },
+                        onFailure: _ => throw new XunitException("Wrong method called"));
+
+                    actualReturn.Should().Be(expectedReturn, "onSuccess should have been called");
+                }
+            }
+        }
+    }
+}

--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -1,6 +1,7 @@
 using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using Bearded.Utilities.Monads;
 
 namespace Bearded.Utilities
 {
@@ -20,6 +21,14 @@ namespace Bearded.Utilities
         internal static Maybe<T> Just(T value) => new Maybe<T>(value);
 
         public T ValueOrDefault(T @default) => hasValue ? value : @default;
+
+        public T ValueOrDefault(Func<T> defaultProvider) => hasValue ? value : defaultProvider();
+
+        public Result<T, TError> ValueOrFailure<TError>(TError error) =>
+            hasValue ? (Result<T, TError>) Result.Success(value) : Result.Failure(error);
+
+        public Result<T, TError> ValueOrFailure<TError>(Func<TError> errorProvider) =>
+            hasValue ? (Result<T, TError>) Result.Success(value) : Result.Failure(errorProvider());
 
         public Maybe<TOut> Select<TOut>(Func<T, TOut> selector) =>
             hasValue ? Maybe.Just(selector(value)) : Maybe<TOut>.Nothing;

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -74,13 +74,7 @@ namespace Bearded.Utilities.Monads
         public static bool operator !=(Result<TResult, TError> left, Result<TResult, TError> right) =>
             !left.Equals(right);
 
-        public override int GetHashCode()
-        {
-            var hashCode = isSuccess.GetHashCode();
-            hashCode = (hashCode * 397) ^ EqualityComparer<TResult>.Default.GetHashCode(result);
-            hashCode = (hashCode * 397) ^ EqualityComparer<TError>.Default.GetHashCode(error);
-            return hashCode;
-        }
+        public override int GetHashCode() => HashCode.Combine(isSuccess, result, error);
 
         public override string ToString() => isSuccess ? $"success {result}" : $"error {error}";
 

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -106,7 +106,7 @@ namespace Bearded.Utilities.Monads
 
     public readonly struct Success<T>
     {
-        public readonly T Result;
+        public T Result { get; }
 
         internal Success(T result)
         {
@@ -116,7 +116,7 @@ namespace Bearded.Utilities.Monads
 
     public readonly struct Failure<T>
     {
-        public readonly T Error;
+        public T Error { get; }
 
         internal Failure(T error)
         {

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -1,0 +1,128 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+
+namespace Bearded.Utilities.Monads
+{
+    public readonly struct Result<TResult, TError> : IEquatable<Result<TResult, TError>>
+    {
+        private readonly bool isSuccess;
+        private readonly TResult result;
+        private readonly TError error;
+
+        private Result(bool isSuccess, TResult result, TError error)
+        {
+            this.isSuccess = isSuccess;
+            this.result = result;
+            this.error = error;
+        }
+
+        public TResult ResultOrDefault(TResult @default) => isSuccess ? result : @default;
+
+        public TResult ResultOrDefault(Func<TResult> defaultProvider) => isSuccess ? result : defaultProvider();
+
+        public TResult ResultOrThrow(Func<TError, Exception> exceptionProvider) =>
+            isSuccess ? result : throw exceptionProvider(error);
+
+        public Result<TOut, TError> Select<TOut>(Func<TResult, TOut> selector) =>
+            isSuccess ? (Result<TOut, TError>) Result.Success(selector(result)) : Result.Failure(error);
+
+        public Result<TOut, TError> SelectMany<TOut>(Func<TResult, Result<TOut, TError>> selector) =>
+            isSuccess ? selector(result) : Result.Failure(error);
+
+        public void Match(Action<TResult> onSuccess)
+        {
+            if (isSuccess)
+            {
+                onSuccess(result);
+            }
+        }
+
+        public void Match(Action<TResult> onSuccess, Action<TError> onFailure)
+        {
+            if (isSuccess)
+            {
+                onSuccess(result);
+            }
+            else
+            {
+                onFailure(error);
+            }
+        }
+
+        public TOut Match<TOut>(Func<TResult, TOut> onSuccess, Func<TError, TOut> onFailure) =>
+            isSuccess ? onSuccess(result) : onFailure(error);
+
+        public bool Equals(Result<TResult, TError> other) =>
+            isSuccess == other.isSuccess
+            && EqualityComparer<TResult>.Default.Equals(result, other.result)
+            && EqualityComparer<TError>.Default.Equals(error, other.error);
+
+        public override bool Equals(object obj) => obj is Result<TResult, TError> other && Equals(other);
+
+        public static bool operator ==(Result<TResult, TError> left, Result<TResult, TError> right) =>
+            left.Equals(right);
+
+        public static bool operator !=(Result<TResult, TError> left, Result<TResult, TError> right) =>
+            !left.Equals(right);
+
+        public override int GetHashCode()
+        {
+            var hashCode = isSuccess.GetHashCode();
+            hashCode = (hashCode * 397) ^ EqualityComparer<TResult>.Default.GetHashCode(result);
+            hashCode = (hashCode * 397) ^ EqualityComparer<TError>.Default.GetHashCode(error);
+            return hashCode;
+        }
+
+        public override string ToString() => isSuccess ? $"success {result}" : $"error {error}";
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Result<TResult, TError>(Success<TResult> success)
+        {
+            return new Result<TResult, TError>(true, success.Result, default);
+        }
+
+        [MethodImpl(MethodImplOptions.AggressiveInlining)]
+        public static implicit operator Result<TResult, TError>(Failure<TError> failure)
+        {
+            return new Result<TResult, TError>(false, default, failure.Error);
+        }
+    }
+
+    public static class Result
+    {
+        public static Result<TResult, TError> Success<TResult, TError>(TResult result) => Success(result);
+
+        public static Success<T> Success<T>(T result) => new Success<T>(result);
+
+        public static Result<TResult, TError> Failure<TResult, TError>(TError error) => Failure(error);
+
+        public static Failure<T> Failure<T>(T error) => new Failure<T>(error);
+
+        public static TResult ResultOrThrow<TResult, TError>(this Result<TResult, TError> result)
+            where TError : Exception
+        {
+            return result.ResultOrThrow(e => e);
+        }
+    }
+
+    public readonly struct Success<T>
+    {
+        internal readonly T Result;
+
+        internal Success(T result)
+        {
+            Result = result;
+        }
+    }
+
+    public readonly struct Failure<T>
+    {
+        internal readonly T Error;
+
+        internal Failure(T error)
+        {
+            Error = error;
+        }
+    }
+}

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -17,6 +17,12 @@ namespace Bearded.Utilities.Monads
             this.error = error;
         }
 
+        public static Result<TResult, TError> Success(TResult result) =>
+            new Result<TResult, TError>(true, result, default);
+
+        public static Result<TResult, TError> Failure(TError error) =>
+            new Result<TResult, TError>(false, default, error);
+
         public TResult ResultOrDefault(TResult @default) => isSuccess ? result : @default;
 
         public TResult ResultOrDefault(Func<TResult> defaultProvider) => isSuccess ? result : defaultProvider();
@@ -79,25 +85,21 @@ namespace Bearded.Utilities.Monads
         public override string ToString() => isSuccess ? $"success {result}" : $"error {error}";
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Result<TResult, TError>(Success<TResult> success)
-        {
-            return new Result<TResult, TError>(true, success.Result, default);
-        }
+        public static implicit operator Result<TResult, TError>(Success<TResult> success) => Success(success.Result);
 
         [MethodImpl(MethodImplOptions.AggressiveInlining)]
-        public static implicit operator Result<TResult, TError>(Failure<TError> failure)
-        {
-            return new Result<TResult, TError>(false, default, failure.Error);
-        }
+        public static implicit operator Result<TResult, TError>(Failure<TError> failure) => Failure(failure.Error);
     }
 
     public static class Result
     {
-        public static Result<TResult, TError> Success<TResult, TError>(TResult result) => Success(result);
+        public static Result<TResult, TError> Success<TResult, TError>(TResult result) =>
+            Result<TResult, TError>.Success(result);
 
         public static Success<T> Success<T>(T result) => new Success<T>(result);
 
-        public static Result<TResult, TError> Failure<TResult, TError>(TError error) => Failure(error);
+        public static Result<TResult, TError> Failure<TResult, TError>(TError error) =>
+            Result<TResult, TError>.Failure(error);
 
         public static Failure<T> Failure<T>(T error) => new Failure<T>(error);
 

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Runtime.CompilerServices;
 
 namespace Bearded.Utilities.Monads
@@ -7,10 +8,12 @@ namespace Bearded.Utilities.Monads
     public readonly struct Result<TResult, TError> : IEquatable<Result<TResult, TError>>
     {
         private readonly bool isSuccess;
+        [AllowNull]
         private readonly TResult result;
+        [AllowNull]
         private readonly TError error;
 
-        private Result(bool isSuccess, TResult result, TError error)
+        private Result(bool isSuccess, [AllowNull] TResult result, [AllowNull] TError error)
         {
             this.isSuccess = isSuccess;
             this.result = result;
@@ -46,7 +49,7 @@ namespace Bearded.Utilities.Monads
             }
         }
 
-        public void Match(Action<TResult> onSuccess, Action<TError> onFailure)
+        public void Match(Action<TResult> onSuccess, FailureResultCallback<TError> onFailure)
         {
             if (isSuccess)
             {
@@ -58,7 +61,7 @@ namespace Bearded.Utilities.Monads
             }
         }
 
-        public TOut Match<TOut>(Func<TResult, TOut> onSuccess, Func<TError, TOut> onFailure) =>
+        public TOut Match<TOut>(Func<TResult, TOut> onSuccess, FailureResultTransformation<TError, TOut> onFailure) =>
             isSuccess ? onSuccess(result) : onFailure(error);
 
         public bool Equals(Result<TResult, TError> other) =>
@@ -66,7 +69,7 @@ namespace Bearded.Utilities.Monads
             && EqualityComparer<TResult>.Default.Equals(result, other.result)
             && EqualityComparer<TError>.Default.Equals(error, other.error);
 
-        public override bool Equals(object obj) => obj is Result<TResult, TError> other && Equals(other);
+        public override bool Equals(object? obj) => obj is Result<TResult, TError> other && Equals(other);
 
         public static bool operator ==(Result<TResult, TError> left, Result<TResult, TError> right) =>
             left.Equals(right);
@@ -123,4 +126,8 @@ namespace Bearded.Utilities.Monads
             Error = error;
         }
     }
+
+    public delegate void FailureResultCallback<in TError>([MaybeNull] TError error);
+
+    public delegate TOut FailureResultTransformation<in TError, out TOut>([MaybeNull] TError error);
 }

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -24,6 +24,8 @@ namespace Bearded.Utilities.Monads
         public TResult ResultOrThrow(Func<TError, Exception> exceptionProvider) =>
             isSuccess ? result : throw exceptionProvider(error);
 
+        public Maybe<TResult> ResultMaybe() => isSuccess ? Maybe.Just(result) : Maybe.Nothing;
+
         public Result<TOut, TError> Select<TOut>(Func<TResult, TOut> selector) =>
             isSuccess ? (Result<TOut, TError>) Result.Success(selector(result)) : Result.Failure(error);
 

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -110,7 +110,7 @@ namespace Bearded.Utilities.Monads
 
     public readonly struct Success<T>
     {
-        internal readonly T Result;
+        public readonly T Result;
 
         internal Success(T result)
         {
@@ -120,7 +120,7 @@ namespace Bearded.Utilities.Monads
 
     public readonly struct Failure<T>
     {
-        internal readonly T Error;
+        public readonly T Error;
 
         internal Failure(T error)
         {

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -30,7 +30,7 @@ namespace Bearded.Utilities.Monads
         public TResult ResultOrThrow(Func<TError, Exception> exceptionProvider) =>
             isSuccess ? result : throw exceptionProvider(error);
 
-        public Maybe<TResult> ResultMaybe() => isSuccess ? Maybe.Just(result) : Maybe.Nothing;
+        public Maybe<TResult> AsMaybe() => isSuccess ? Maybe.Just(result) : Maybe.Nothing;
 
         public Result<TOut, TError> Select<TOut>(Func<TResult, TOut> selector) =>
             isSuccess ? (Result<TOut, TError>) Result.Success(selector(result)) : Result.Failure(error);


### PR DESCRIPTION
## ✨ What's this?
This PR adds a `Result` monad, implemented much in the same fashion as the existing `Maybe` monad.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
The `Result` monad allows methods to return either a success or an error state without having to rely on exceptions.

## 🏗 How is it done?
The `Result` monad follows the patterns of the `Maybe` monad pretty closely.

A readonly generic `Result` struct represents the actual monad. A static non-generic `Result` is added for easier factory methods. Finally, generic `Success` and `Failure` structs are added to allow easy upcasting to a `Result`, similar to how `NothingMaybe` allows upcasting to `Maybe`. This means code can do `Result.Success(myResult)` and as long as the compiler can figure out the error from context (for example the return value of your method), it should work. Note that this isn't infallible, as you can see in the tests.

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
Structs are good?

### 🦋 Side effects
I made the choice of putting the `Result` monad into a new `Monads` namespace instead of `Core`. `Maybe` should probably move there as well, which will be a future breaking change.

## 💡 Review hints
N/A
