### PR TITLE
🐛 Fix the conversion constants between Direction2 and degrees/radians

### DIFF
--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -9,11 +9,13 @@ namespace Bearded.Utilities.Geometry
     /// </summary>
     public readonly struct Direction2 : IEquatable<Direction2>, IFormattable
     {
-        private const float fromRadians = uint.MaxValue / Mathf.TwoPi;
-        private const float toRadians = Mathf.TwoPi / uint.MaxValue;
+        private const long numSteps = (1l << 32);
 
-        private const float fromDegrees = uint.MaxValue / 360f;
-        private const float toDegrees = 360f / uint.MaxValue;
+        private const float fromRadians = numSteps / Mathf.TwoPi;
+        private const float toRadians = Mathf.TwoPi / numSteps;
+
+        private const float fromDegrees = numSteps / 360f;
+        private const float toDegrees = 360f / numStepse;
 
         private readonly uint data;
 

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -9,13 +9,13 @@ namespace Bearded.Utilities.Geometry
     /// </summary>
     public readonly struct Direction2 : IEquatable<Direction2>, IFormattable
     {
-        private const long numSteps = (1l << 32);
+        private const long numSteps = (1L << 32);
 
         private const float fromRadians = numSteps / Mathf.TwoPi;
         private const float toRadians = Mathf.TwoPi / numSteps;
 
         private const float fromDegrees = numSteps / 360f;
-        private const float toDegrees = 360f / numStepse;
+        private const float toDegrees = 360f / numSteps;
 
         private readonly uint data;
 


### PR DESCRIPTION
## ✨ What's this?
This PR fixes a bug in the `Direction2` class. Specifically, the conversions to and from radians and degrees are slightly off.

The implementation of `Direction2` assumes that the complete space of directions is split into 2^32 steps, and each of those steps is uniquely identified using a `uint`. To calculate to and from radians and degrees, we just need to know the corresponding bucket size in radians and degrees. This is done by calculating 2pi and 360 by `uint.MaxValue` respectively. However, since `uint` can take on the value 0, the maximum value is actually 2^32 - 1, meaning we are not currently calculating the bucket size correctly.

This can easily be seen by manually stepping through the code for converting 2pi into a direction. We calculate `(2pi * (uint.MaxValue / 2pi))`, where we can cross out the 2pi, getting `uint.MaxValue`. A direction from 0 radians should be equivalent, but this would return a direction with `0` as data.

The correct values here then are dividing 2pi and 360 by 2^32 instead of 2^32 - 1. The smallest integer type in C# that can hold this value is a long.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
It ensures that `Direction2` is correctly implemented.

## 🏗 How is it done?
See above.

### 💥 Breaking changes
The only code that is broken would have made wrong assumptions about the code in the first place. This PR does not break any documented semantics. In fact, it fixes them.

### 🔬 Why not another way?
Cannot think of any solutions.

### 🦋 Side effects
N/A

## 💡 Review hints
N/A
