### PR TITLE
💄 Remove redundant qualifiers

### DIFF
--- a/Bearded.Utilities.Testing.Tests/Core/MaybeAssertionsTests.cs
+++ b/Bearded.Utilities.Testing.Tests/Core/MaybeAssertionsTests.cs
@@ -15,77 +15,77 @@ namespace Bearded.Utilities.Testing.Tests
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust();
-            
+
                 assertion.Should().NotThrow();
             }
-        
+
             [Fact]
             public void FailsWhenNothing()
             {
                 var maybe = Maybe<int>.Nothing;
 
                 Action assertion = () => maybe.Should().BeJust();
-            
+
                 assertion.Should().Throw<XunitException>();
             }
-            
+
             [Fact]
             public void ReturnsAndConstraintThatSucceedsAsExpected()
             {
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust().And.Should().NotBeNull();
-            
+
                 assertion.Should().NotThrow();
             }
-        
+
             [Fact]
             public void ReturnsAndConstraintThatFailsAsExpected()
             {
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust().And.Should().BeNull();
-            
+
                 assertion.Should().Throw<XunitException>();
             }
-            
+
             [Fact]
             public void FailsWhenNothingEvenIfAndConstraintSucceeds()
             {
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust().And.Should().NotBeNull();
-            
+
                 assertion.Should().NotThrow();
             }
-            
+
             [Fact]
             public void ReturnsWhichConstraintThatSucceedsAsExpected()
             {
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust().Which.Should().Be(100);
-            
+
                 assertion.Should().NotThrow();
             }
-        
+
             [Fact]
             public void ReturnsWhichConstraintThatFailsAsExpected()
             {
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust().Which.Should().Be(200);
-            
+
                 assertion.Should().Throw<XunitException>();
             }
-            
+
             [Fact]
             public void FailsWhenNothingEvenIfWhichConstraintSucceeds()
             {
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust().Which.Should().Be(100);
-            
+
                 assertion.Should().NotThrow();
             }
         }
@@ -98,7 +98,7 @@ namespace Bearded.Utilities.Testing.Tests
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust(100);
-            
+
                 assertion.Should().NotThrow();
             }
 
@@ -108,7 +108,7 @@ namespace Bearded.Utilities.Testing.Tests
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeJust(200);
-            
+
                 assertion.Should().Throw<XunitException>();
             }
 
@@ -118,7 +118,7 @@ namespace Bearded.Utilities.Testing.Tests
                 var maybe = Maybe<int>.Nothing;
 
                 Action assertion = () => maybe.Should().BeJust(200);
-            
+
                 assertion.Should().Throw<XunitException>();
             }
         }
@@ -131,7 +131,7 @@ namespace Bearded.Utilities.Testing.Tests
                 var maybe = Maybe<int>.Nothing;
 
                 Action assertion = () => maybe.Should().BeNothing();
-            
+
                 assertion.Should().NotThrow();
             }
 
@@ -141,7 +141,7 @@ namespace Bearded.Utilities.Testing.Tests
                 var maybe = Maybe.Just(100);
 
                 Action assertion = () => maybe.Should().BeNothing();
-            
+
                 assertion.Should().Throw<XunitException>();
             }
         }

--- a/Bearded.Utilities/Collections/MutableLinkedListEnumerator.cs
+++ b/Bearded.Utilities/Collections/MutableLinkedListEnumerator.cs
@@ -30,49 +30,49 @@ namespace Bearded.Utilities.Collections
 
         public T Current
         {
-            get { return this.current.Value; }
+            get { return current.Value; }
         }
 
         private MutableLinkedListNode<T> current;
 
         public void OnObjectRemove(MutableLinkedListNode<T> obj)
         {
-            if (obj != this.current)
+            if (obj != current)
                 return;
 
-            this.currentWasDeleted = true;
-            this.current = obj.Next;
-            if (this.current == null)
-                this.done = true;
+            currentWasDeleted = true;
+            current = obj.Next;
+            if (current == null)
+                done = true;
         }
 
         public void Dispose()
         {
-            this.list.ForgetEnumerator(this.node);
+            list.ForgetEnumerator(node);
         }
 
         public bool MoveNext()
         {
-            if (this.done)
+            if (done)
                 return false;
-            if (!this.initialised)
+            if (!initialised)
             {
-                if (this.list.Count == 0)
+                if (list.Count == 0)
                     return false;
-                this.initialised = true;
-                this.current = this.list.First;
+                initialised = true;
+                current = list.First;
             }
             else
             {
-                if (this.currentWasDeleted)
+                if (currentWasDeleted)
                 {
-                    this.currentWasDeleted = false;
+                    currentWasDeleted = false;
                     return true;
                 }
-                this.current = this.current.Next;
-                if (this.current == null)
+                current = current.Next;
+                if (current == null)
                 {
-                    this.done = true;
+                    done = true;
                     return false;
                 }
             }
@@ -81,15 +81,15 @@ namespace Bearded.Utilities.Collections
 
         public void Reset()
         {
-            this.current = null;
-            this.done = false;
-            this.initialised = false;
-            this.currentWasDeleted = false;
+            current = null;
+            done = false;
+            initialised = false;
+            currentWasDeleted = false;
         }
 
         object System.Collections.IEnumerator.Current
         {
-            get { return this.Current; }
+            get { return Current; }
         }
 
     }

--- a/Bearded.Utilities/Collections/MutableLinkedListNode.cs
+++ b/Bearded.Utilities/Collections/MutableLinkedListNode.cs
@@ -30,7 +30,7 @@ namespace Bearded.Utilities.Collections
         /// <summary>
         /// The value stored in the node.
         /// </summary>
-        public T Value { get { return this.value; } }
+        public T Value { get { return value; } }
 
         // Next, Prev and List are internally writeable to
         // simplify addition, removal and insertion code.
@@ -56,7 +56,7 @@ namespace Bearded.Utilities.Collections
 
         internal MutableLinkedListNode()
         {
-            this.value = this as T;
+            value = this as T;
         }
 
         #endregion
@@ -89,7 +89,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="beforeThis">The node to add this before.</param>
         public void InsertBefore(MutableLinkedListNode<T> beforeThis)
         {
-            this.List.InsertBefore(this, beforeThis);
+            List.InsertBefore(this, beforeThis);
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Bearded.Utilities.Collections
         /// </summary>
         public void RemoveFromList()
         {
-            this.List.Remove(this);
+            List.Remove(this);
         }
 
         #endregion

--- a/Bearded.Utilities/Collections/PriorityQueue.cs
+++ b/Bearded.Utilities/Collections/PriorityQueue.cs
@@ -32,11 +32,11 @@ namespace Bearded.Utilities.Collections
         public PriorityQueue(IEnumerable<KeyValuePair<TPriority, TValue>> data)
         {
             this.data = data.ToArray();
-            this.Count = this.data.Length;
+            Count = this.data.Length;
             for (int i = 0; i < this.data.Length; i++)
-                this.valueDict.Add(this.data[i].Value, i);
+                valueDict.Add(this.data[i].Value, i);
             for (int i = this.data.Length / 2 - 1; i >= 0; i--)
-                this.cascadeDown(i);
+                cascadeDown(i);
         }
 
         /// <summary>
@@ -46,11 +46,11 @@ namespace Bearded.Utilities.Collections
         /// <param name="newPriority">The new priority of the element.</param>
         public void DecreasePriority(TValue value, TPriority newPriority)
         {
-            int i = this.valueDict[value];
-            if (this.data[i].Key.CompareTo(newPriority) < 0)
+            int i = valueDict[value];
+            if (data[i].Key.CompareTo(newPriority) < 0)
                 throw new InvalidOperationException("Can not increase the priority.");
-            this.data[i] = new KeyValuePair<TPriority, TValue>(newPriority, value);
-            this.cascadeUp(i);
+            data[i] = new KeyValuePair<TPriority, TValue>(newPriority, value);
+            cascadeUp(i);
         }
 
         /// <summary>
@@ -59,7 +59,7 @@ namespace Bearded.Utilities.Collections
         public override void Clear()
         {
             base.Clear();
-            this.valueDict.Clear();
+            valueDict.Clear();
         }
 
         /// <summary>
@@ -69,7 +69,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="value">The element itself.</param>
         protected override void add(TPriority priority, TValue value)
         {
-            this.valueDict.Add(value, this.Count);
+            valueDict.Add(value, Count);
             base.add(priority, value);
         }
 
@@ -80,8 +80,8 @@ namespace Bearded.Utilities.Collections
         /// <param name="i2">The index of the second element.</param>
         protected override void swap(int i1, int i2)
         {
-            this.valueDict[this.data[i1].Value] = i2;
-            this.valueDict[this.data[i2].Value] = i1;
+            valueDict[data[i1].Value] = i2;
+            valueDict[data[i2].Value] = i1;
 
             base.swap(i1, i2);
         }
@@ -92,7 +92,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="i">The index of the element to be removed.</param>
         protected override void reset(int i)
         {
-            this.valueDict.Remove(this.data[i].Value);
+            valueDict.Remove(data[i].Value);
 
             base.reset(i);
         }

--- a/Bearded.Utilities/Collections/StaticPriorityQueue.cs
+++ b/Bearded.Utilities/Collections/StaticPriorityQueue.cs
@@ -35,7 +35,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="capacity">Initial capacity of the priority queue.</param>
         public StaticPriorityQueue(int capacity)
         {
-            this.data = new KeyValuePair<TPriority, TValue>[capacity];
+            data = new KeyValuePair<TPriority, TValue>[capacity];
         }
 
         /// <summary>
@@ -45,9 +45,9 @@ namespace Bearded.Utilities.Collections
         public StaticPriorityQueue(IEnumerable<KeyValuePair<TPriority, TValue>> data)
         {
             this.data = data.ToArray();
-            this.Count = this.data.Length;
+            Count = this.data.Length;
             for (int i = this.data.Length / 2 - 1; i >= 0; i--)
-                this.cascadeDown(i);
+                cascadeDown(i);
         }
 
         /// <summary>
@@ -57,12 +57,12 @@ namespace Bearded.Utilities.Collections
         /// <param name="value">The element itself.</param>
         public void Enqueue(TPriority priority, TValue value)
         {
-            if (this.Count == this.data.Length)
-                this.increaseCapacity();
+            if (Count == data.Length)
+                increaseCapacity();
 
-            this.add(priority, value);
-            this.cascadeUp(this.Count);
-            this.Count++;
+            add(priority, value);
+            cascadeUp(Count);
+            Count++;
         }
 
         /// <summary>
@@ -71,10 +71,10 @@ namespace Bearded.Utilities.Collections
         /// <returns>The element with the lowest priority.</returns>
         public KeyValuePair<TPriority, TValue> Peek()
         {
-            if (this.Count == 0)
+            if (Count == 0)
                 throw new InvalidOperationException();
 
-            return this.data[0];
+            return data[0];
         }
 
         /// <summary>
@@ -83,14 +83,14 @@ namespace Bearded.Utilities.Collections
         /// <returns>The element with the lowest priority.</returns>
         public KeyValuePair<TPriority, TValue> Dequeue()
         {
-            if (this.Count == 0)
+            if (Count == 0)
                 throw new InvalidOperationException();
 
-            var oldRoot = this.data[0];
-            this.swap(0, this.Count - 1);
-            this.reset(this.Count - 1);
-            this.Count--;
-            this.cascadeDown(0);
+            var oldRoot = data[0];
+            swap(0, Count - 1);
+            reset(Count - 1);
+            Count--;
+            cascadeDown(0);
 
             return oldRoot;
         }
@@ -100,15 +100,15 @@ namespace Bearded.Utilities.Collections
         /// </summary>
         public virtual void Clear()
         {
-            this.data = new KeyValuePair<TPriority, TValue>[this.data.Length];
-            this.Count = 0;
+            data = new KeyValuePair<TPriority, TValue>[data.Length];
+            Count = 0;
         }
 
         private void increaseCapacity()
         {
-            var newData = new KeyValuePair<TPriority, TValue>[2 * this.data.Length + 1];
+            var newData = new KeyValuePair<TPriority, TValue>[2 * data.Length + 1];
             Array.Copy(data, newData, data.Length);
-            this.data = newData;
+            data = newData;
         }
 
         /// <summary>
@@ -122,7 +122,7 @@ namespace Bearded.Utilities.Collections
                 var parent = getParent(i);
 
                 if (data[i].Key.CompareTo(data[parent].Key) < 0)
-                    this.swap(i, parent);
+                    swap(i, parent);
                 else return;
 
                 i = parent;
@@ -141,15 +141,15 @@ namespace Bearded.Utilities.Collections
                 var right = getRightChild(i);
                 var smallest = i;
 
-                if (left < this.Count && this.data[left].Key.CompareTo(this.data[smallest].Key) < 0)
+                if (left < Count && data[left].Key.CompareTo(data[smallest].Key) < 0)
                     smallest = left;
-                if (right < this.Count && this.data[right].Key.CompareTo(this.data[smallest].Key) < 0)
+                if (right < Count && data[right].Key.CompareTo(data[smallest].Key) < 0)
                     smallest = right;
 
                 if (smallest == i)
                     return;
 
-                this.swap(i, smallest);
+                swap(i, smallest);
                 i = smallest;
             }
         }
@@ -162,7 +162,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="value">The element itself.</param>
         protected virtual void add(TPriority priority, TValue value)
         {
-            this.data[this.Count] = new KeyValuePair<TPriority, TValue>(priority, value);
+            data[Count] = new KeyValuePair<TPriority, TValue>(priority, value);
         }
 
         /// <summary>
@@ -172,9 +172,9 @@ namespace Bearded.Utilities.Collections
         /// <param name="i2">The index of the second element.</param>
         protected virtual void swap(int i1, int i2)
         {
-            var oldFirst = this.data[i1];
-            this.data[i1] = this.data[i2];
-            this.data[i2] = oldFirst;
+            var oldFirst = data[i1];
+            data[i1] = data[i2];
+            data[i2] = oldFirst;
         }
 
         /// <summary>
@@ -183,7 +183,7 @@ namespace Bearded.Utilities.Collections
         /// <param name="i">The index of the element to be removed.</param>
         protected virtual void reset(int i)
         {
-            this.data[i] = default;
+            data[i] = default;
         }
         #endregion
 

--- a/Bearded.Utilities/Core/MathExtensions.cs
+++ b/Bearded.Utilities/Core/MathExtensions.cs
@@ -87,23 +87,23 @@ namespace Bearded.Utilities
         /// <summary>
         /// Returns the square root of the specified number.
         /// </summary>
-        public static float Sqrted(this float f) => (float)System.Math.Sqrt(f);
+        public static float Sqrted(this float f) => (float)Math.Sqrt(f);
 
         /// <summary>
         /// Returns the square root of the specified number.
         /// </summary>
-        public static double Sqrted(this double d) => System.Math.Sqrt(d);
+        public static double Sqrted(this double d) => Math.Sqrt(d);
 
 
         /// <summary>
         /// Returns a specified number raised to the specified power.
         /// </summary>
-        public static float Powed(this float b, float power) => (float)System.Math.Pow(b, power);
+        public static float Powed(this float b, float power) => (float)Math.Pow(b, power);
 
         /// <summary>
         /// Returns a specified number raised to the specified power.
         /// </summary>
-        public static double Powed(this double b, double power) => System.Math.Pow(b, power);
+        public static double Powed(this double b, double power) => Math.Pow(b, power);
 
         #endregion
 
@@ -113,32 +113,32 @@ namespace Bearded.Utilities
         /// <summary>
         /// Returns the cosine of the specified angle.
         /// </summary>
-        public static float Cos(this float f) => (float)System.Math.Cos(f);
+        public static float Cos(this float f) => (float)Math.Cos(f);
 
         /// <summary>
         /// Returns the sine of the specified angle.
         /// </summary>
-        public static float Sin(this float f) => (float)System.Math.Sin(f);
+        public static float Sin(this float f) => (float)Math.Sin(f);
 
         /// <summary>
         /// Returns the tangent of the specified angle.
         /// </summary>
-        public static float Tan(this float f) => (float)System.Math.Tan(f);
+        public static float Tan(this float f) => (float)Math.Tan(f);
 
         /// <summary>
         /// Returns the angle whose cosine is the specified number.
         /// </summary>
-        public static float Acos(this float f) => (float)System.Math.Acos(f);
+        public static float Acos(this float f) => (float)Math.Acos(f);
 
         /// <summary>
         /// Returns the angle whose sine is the specified number.
         /// </summary>
-        public static float Asin(this float f) => (float)System.Math.Asin(f);
+        public static float Asin(this float f) => (float)Math.Asin(f);
 
         /// <summary>
         /// Returns the angle whose tangent is the specified number.
         /// </summary>
-        public static float Atan(this float f) => (float)System.Math.Atan(f);
+        public static float Atan(this float f) => (float)Math.Atan(f);
 
         #endregion
 
@@ -146,32 +146,32 @@ namespace Bearded.Utilities
         /// <summary>
         /// Returns the cosine of the specified angle.
         /// </summary>
-        public static double Cos(this double d) => System.Math.Cos(d);
+        public static double Cos(this double d) => Math.Cos(d);
 
         /// <summary>
         /// Returns the sine of the specified angle.
         /// </summary>
-        public static double Sin(this double d) => System.Math.Sin(d);
+        public static double Sin(this double d) => Math.Sin(d);
 
         /// <summary>
         /// Returns the tangent of the specified angle.
         /// </summary>
-        public static double Tan(this double d) => System.Math.Tan(d);
+        public static double Tan(this double d) => Math.Tan(d);
 
         /// <summary>
         /// Returns the angle whose cosine is the specified number.
         /// </summary>
-        public static double Acos(this double d) => System.Math.Acos(d);
+        public static double Acos(this double d) => Math.Acos(d);
 
         /// <summary>
         /// Returns the angle whose sine is the specified number.
         /// </summary>
-        public static double Asin(this double d) => System.Math.Asin(d);
+        public static double Asin(this double d) => Math.Asin(d);
 
         /// <summary>
         /// Returns the angle whose tangent is the specified number.
         /// </summary>
-        public static double Atan(this double d) => System.Math.Atan(d);
+        public static double Atan(this double d) => Math.Atan(d);
 
         #endregion
 
@@ -182,34 +182,34 @@ namespace Bearded.Utilities
         /// <summary>
         /// Returns the lowest integral number higher than or equal to the specified number.
         /// </summary>
-        public static int CeiledToInt(float f) => (int)System.Math.Ceiling(f);
+        public static int CeiledToInt(float f) => (int)Math.Ceiling(f);
 
         /// <summary>
         /// Returns the lowest integral number higher than or equal to the specified number.
         /// </summary>
-        public static int CeiledToInt(double d) => (int)System.Math.Ceiling(d);
+        public static int CeiledToInt(double d) => (int)Math.Ceiling(d);
 
 
         /// <summary>
         /// Returns the highest integral number lower than or equal to the specified number.
         /// </summary>
-        public static int FlooredToInt(float f) => (int)System.Math.Floor(f);
+        public static int FlooredToInt(float f) => (int)Math.Floor(f);
 
         /// <summary>
         /// Returns the highest integral number lower than or equal to the specified number.
         /// </summary>
-        public static int FlooredToInt(double d) => (int)System.Math.Floor(d);
+        public static int FlooredToInt(double d) => (int)Math.Floor(d);
 
 
         /// <summary>
         /// Returns the integral number closest to the specified number.
         /// </summary>
-        public static int RoundedToInt(float f) => (int)System.Math.Round(f);
+        public static int RoundedToInt(float f) => (int)Math.Round(f);
 
         /// <summary>
         /// Returns the integral number closest to the specified number.
         /// </summary>
-        public static int RoundedToInt(double d) => (int)System.Math.Round(d);
+        public static int RoundedToInt(double d) => (int)Math.Round(d);
 
         #endregion
 

--- a/Bearded.Utilities/Core/RandomExtensions.cs
+++ b/Bearded.Utilities/Core/RandomExtensions.cs
@@ -36,7 +36,7 @@ namespace Bearded.Utilities
             random.NextBytes(buf);
             var longRand = BitConverter.ToInt64(buf, 0);
 
-            return System.Math.Abs(longRand % (max - min)) + min;
+            return Math.Abs(longRand % (max - min)) + min;
         }
 
         #endregion
@@ -66,7 +66,7 @@ namespace Bearded.Utilities
             // Box-Muller
             var u1 = random.NextDouble();
             var u2 = random.NextDouble();
-            return System.Math.Sqrt(-2 * System.Math.Log(u1)) * System.Math.Cos(2 * System.Math.PI * u2);
+            return Math.Sqrt(-2 * Math.Log(u1)) * Math.Cos(2 * Math.PI * u2);
         }
 
         /// <summary>

--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -42,7 +42,7 @@ namespace Bearded.Utilities.Geometry
         {
             float perpDot = from.Y * to.X - from.X * to.Y;
 
-            return Angle.FromRadians(Mathf.Atan2(perpDot, Vector2.Dot(from, to)));
+            return FromRadians(Mathf.Atan2(perpDot, Vector2.Dot(from, to)));
         }
 
         /// <summary>
@@ -60,7 +60,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Angle BetweenPositive(Direction2 from, Direction2 to)
         {
-            var a = Angle.Between(from, to);
+            var a = Between(from, to);
             if (a.radians < 0)
                 a += Mathf.TwoPi.Radians();
             return a;
@@ -72,7 +72,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Angle BetweenNegative(Direction2 from, Direction2 to)
         {
-            var a = Angle.Between(from, to);
+            var a = Between(from, to);
             if (a.radians > 0)
                 a -= Mathf.TwoPi.Radians();
             return a;
@@ -94,27 +94,27 @@ namespace Bearded.Utilities.Geometry
         /// <summary>
         /// Gets the value of the angle in radians.
         /// </summary>
-        public float Radians => this.radians;
+        public float Radians => radians;
 
         /// <summary>
         /// Gets the value of the angle in degrees.
         /// </summary>
-        public float Degrees => Mathf.RadiansToDegrees(this.radians);
+        public float Degrees => Mathf.RadiansToDegrees(radians);
 
         /// <summary>
         /// Gets a 2x2 rotation matrix that rotates vectors by this angle.
         /// </summary>
-        public Matrix2 Transformation => Matrix2.CreateRotation(this.radians);
+        public Matrix2 Transformation => Matrix2.CreateRotation(radians);
 
         /// <summary>
         /// Gets the magnitude (absolute value) of the angle in radians.
         /// </summary>
-        public float MagnitudeInRadians => System.Math.Abs(this.radians);
+        public float MagnitudeInRadians => Math.Abs(radians);
 
         /// <summary>
         /// Gets the magnitude (absolute value) of the angle in degrees.
         /// </summary>
-        public float MagnitudeInDegrees => System.Math.Abs(this.Degrees);
+        public float MagnitudeInDegrees => Math.Abs(Degrees);
 
         #endregion
 
@@ -127,35 +127,35 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public float Sin()
         {
-            return Mathf.Sin(this.radians);
+            return Mathf.Sin(radians);
         }
         /// <summary>
         /// Returns the Cosine of the angle.
         /// </summary>
         public float Cos()
         {
-            return Mathf.Cos(this.radians);
+            return Mathf.Cos(radians);
         }
         /// <summary>
         /// Returns the Tangent of the angle.
         /// </summary>
         public float Tan()
         {
-            return Mathf.Tan(this.radians);
+            return Mathf.Tan(radians);
         }
         /// <summary>
         /// Returns the Sign of the angle.
         /// </summary>
         public int Sign()
         {
-            return System.Math.Sign(this.radians);
+            return Math.Sign(radians);
         }
         /// <summary>
         /// Returns the absolute value of the angle.
         /// </summary>
         public Angle Abs()
         {
-            return new Angle(System.Math.Abs(this.radians));
+            return new Angle(Math.Abs(radians));
         }
         /// <summary>
         /// Returns a new Angle with |value| == 1 radians and the same sign as this angle.
@@ -163,14 +163,14 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public Angle Normalized()
         {
-            return new Angle(System.Math.Sign(this.radians));
+            return new Angle(Math.Sign(radians));
         }
         /// <summary>
         /// Clamps this angle between a minimum and a maximum angle.
         /// </summary>
         public Angle Clamped(Angle min, Angle max)
         {
-            return Angle.Clamp(this, min, max);
+            return Clamp(this, min, max);
         }
 
         #region Statics
@@ -278,7 +278,7 @@ namespace Bearded.Utilities.Geometry
         /// </returns>
         public bool Equals(Angle other)
         {
-            return this.radians == other.radians;
+            return radians == other.radians;
         }
 
         /// <summary>
@@ -290,7 +290,7 @@ namespace Bearded.Utilities.Geometry
         /// </returns>
         public override bool Equals(object obj)
         {
-			return obj is Angle && this.Equals((Angle)obj);
+			return obj is Angle && Equals((Angle)obj);
         }
 
         /// <summary>
@@ -301,7 +301,7 @@ namespace Bearded.Utilities.Geometry
         /// </returns>
         public override int GetHashCode()
         {
-            return this.radians.GetHashCode();
+            return radians.GetHashCode();
         }
 
         /// <summary>

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -29,7 +29,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Direction2 FromRadians(float radians)
         {
-            return new Direction2((uint)(radians * Direction2.fromRadians));
+            return new Direction2((uint)(radians * fromRadians));
         }
 
         /// <summary>
@@ -37,7 +37,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Direction2 FromDegrees(float degrees)
         {
-            return new Direction2((uint)(degrees * Direction2.fromDegrees));
+            return new Direction2((uint)(degrees * fromDegrees));
         }
 
         /// <summary>
@@ -45,7 +45,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Direction2 Of(Vector2 vector)
         {
-            return Direction2.FromRadians(Mathf.Atan2(vector.Y, vector.X));
+            return FromRadians(Mathf.Atan2(vector.Y, vector.X));
         }
 
         /// <summary>
@@ -55,7 +55,7 @@ namespace Bearded.Utilities.Geometry
         /// <param name="to">The point the directions "points" towards.</param>
         public static Direction2 Between(Vector2 from, Vector2 to)
         {
-            return Direction2.Of(to - from);
+            return Of(to - from);
         }
 
         #endregion
@@ -76,22 +76,22 @@ namespace Bearded.Utilities.Geometry
         /// <summary>
         /// Gets the absolute angle of the direction in radians between 0 and 2pi.
         /// </summary>
-        public float Radians { get { return this.data * Direction2.toRadians; } }
+        public float Radians { get { return data * toRadians; } }
 
         /// <summary>
         /// Gets the absolute angle of the direction in degrees between 0 and 360.
         /// </summary>
-        public float Degrees { get { return this.data * Direction2.toDegrees; } }
+        public float Degrees { get { return data * toDegrees; } }
 
         /// <summary>
         /// Gets the absolute angle of the direction in radians between -pi and pi.
         /// </summary>
-        public float RadiansSigned { get { return (int)this.data * Direction2.toRadians; } }
+        public float RadiansSigned { get { return (int)data * toRadians; } }
 
         /// <summary>
         /// Gets the absolute angle of the direction in degrees between -180 and 180.
         /// </summary>
-        public float DegreesSigned { get { return (int)this.data * Direction2.toDegrees; } }
+        public float DegreesSigned { get { return (int)data * toDegrees; } }
 
         /// <summary>
         /// Gets the unit vector pointing in this direction.
@@ -100,7 +100,7 @@ namespace Bearded.Utilities.Geometry
         {
             get
             {
-                var radians = this.Radians;
+                var radians = Radians;
                 return new Vector2(Mathf.Cos(radians), Mathf.Sin(radians));
             }
         }
@@ -161,7 +161,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Direction2 operator +(Direction2 direction, Angle angle)
         {
-            return new Direction2((uint)(direction.data + angle.Radians * Direction2.fromRadians));
+            return new Direction2((uint)(direction.data + angle.Radians * fromRadians));
         }
 
         /// <summary>
@@ -169,7 +169,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Direction2 operator -(Direction2 direction, Angle angle)
         {
-            return new Direction2((uint)(direction.data - angle.Radians * Direction2.fromRadians));
+            return new Direction2((uint)(direction.data - angle.Radians * fromRadians));
         }
 
         /// <summary>
@@ -178,7 +178,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Angle operator -(Direction2 direction1, Direction2 direction2)
         {
-            return Angle.FromRadians(((int)direction1.data - (int)direction2.data) * Direction2.toRadians);
+            return Angle.FromRadians(((int)direction1.data - (int)direction2.data) * toRadians);
         }
 
         /// <summary>
@@ -202,7 +202,7 @@ namespace Bearded.Utilities.Geometry
         /// </returns>
         public bool Equals(Direction2 other)
         {
-            return this.data == other.data;
+            return data == other.data;
         }
 
         /// <summary>
@@ -214,7 +214,7 @@ namespace Bearded.Utilities.Geometry
         /// </returns>
         public override bool Equals(object obj)
         {
-            return obj is Direction2 && this.Equals((Direction2)obj);
+            return obj is Direction2 && Equals((Direction2)obj);
         }
 
         /// <summary>
@@ -225,7 +225,7 @@ namespace Bearded.Utilities.Geometry
         /// </returns>
         public override int GetHashCode()
         {
-            return this.data.GetHashCode();
+            return data.GetHashCode();
         }
 
         /// <summary>

--- a/Bearded.Utilities/Geometry/arcs/Arc.cs
+++ b/Bearded.Utilities/Geometry/arcs/Arc.cs
@@ -23,8 +23,8 @@ namespace Bearded.Utilities.Geometry
         {
             get
             {
-                this.ensureInitialized();
-                return this.length;
+                ensureInitialized();
+                return length;
             }
         }
         #endregion
@@ -36,7 +36,7 @@ namespace Bearded.Utilities.Geometry
         /// <param name="segments">The amount of linear segments the arc is split in. A larger amount of segments results in higher precision for length and remapping.</param>
         protected Arc(int segments = 100)
         {
-            this.segmentLengths = new float[segments + 1];
+            segmentLengths = new float[segments + 1];
         }
 
         // This class is lazy as our children might need to set fields
@@ -44,26 +44,26 @@ namespace Bearded.Utilities.Geometry
         // getPointAt and getDistanceBetween methods correctly.
         private void ensureInitialized()
         {
-            if (this.initialized)
+            if (initialized)
                 return;
 
-            this.segmentLengths[0] = 0;
-            T prev = this.getPointAt(0);
+            segmentLengths[0] = 0;
+            T prev = getPointAt(0);
 
             float totalLength = 0;
-            float step = 1.0f / (this.segmentLengths.Length - 1);
+            float step = 1.0f / (segmentLengths.Length - 1);
 
-            for (int i = 1; i < this.segmentLengths.Length; i++)
+            for (int i = 1; i < segmentLengths.Length; i++)
             {
                 float t = i * step;
-                T curr = this.getPointAt(t);
-                totalLength += this.getDistanceBetween(prev, curr);
-                this.segmentLengths[i] = totalLength;
+                T curr = getPointAt(t);
+                totalLength += getDistanceBetween(prev, curr);
+                segmentLengths[i] = totalLength;
                 prev = curr;
             }
 
-            this.length = totalLength;
-            this.initialized = true;
+            length = totalLength;
+            initialized = true;
         }
         #endregion
 
@@ -90,7 +90,7 @@ namespace Bearded.Utilities.Geometry
         /// <returns>The coordinates of the point on the arc at the specified parameter.</returns>
         public T GetPointAt(float t)
         {
-            return this.getPointAt(t);
+            return getPointAt(t);
         }
 
         /// <summary>
@@ -100,8 +100,8 @@ namespace Bearded.Utilities.Geometry
         /// <returns>The coordinates of the point on the arc at the specified parameter.</returns>
         public T GetPointAtNormalised(float t)
         {
-            this.ensureInitialized();
-            return this.getPointAt(this.mapDistance(t.Clamped(0, 1) * this.Length));
+            ensureInitialized();
+            return getPointAt(mapDistance(t.Clamped(0, 1) * Length));
         }
         #endregion
 
@@ -110,24 +110,24 @@ namespace Bearded.Utilities.Geometry
         {
             if (distance <= 0)
                 return 0;
-            if (distance >= this.Length)
+            if (distance >= Length)
                 return 1;
 
-            int i = this.findSegmentLengthIndex(distance);
-            float step = 1.0f / this.segmentLengths.Length;
-            if (this.segmentLengths[i] == distance)
+            int i = findSegmentLengthIndex(distance);
+            float step = 1.0f / segmentLengths.Length;
+            if (segmentLengths[i] == distance)
                 return i * step;
             if (i == 0)
                 return 0;
 
-            float over = distance - this.segmentLengths[i - 1];
-            float ratio = over / (this.segmentLengths[i] - this.segmentLengths[i - 1]);
+            float over = distance - segmentLengths[i - 1];
+            float ratio = over / (segmentLengths[i] - segmentLengths[i - 1]);
             return (i + ratio) * step;
         }
 
         private int findSegmentLengthIndex(float distance)
         {
-            int index = Array.BinarySearch(this.segmentLengths, distance);
+            int index = Array.BinarySearch(segmentLengths, distance);
             return index < 0 ? ~index : 0;
         }
         #endregion

--- a/Bearded.Utilities/Input/MouseEvents.cs
+++ b/Bearded.Utilities/Input/MouseEvents.cs
@@ -4,7 +4,7 @@ namespace Bearded.Utilities.Input
 {
     sealed class MouseEvents
     {
-        private float scrollSinceLastFrame = 0;
+        private float scrollSinceLastFrame;
 
         internal float DeltaScrollF { get; private set; }
 

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -149,10 +149,10 @@ namespace Bearded.Utilities.SpaceTime
         #region static methods
 
         public static Squared<T> Min(Squared<T> s1, Squared<T> s2)
-            => new Squared<T>(System.Math.Min(s1.NumericValue, s2.NumericValue));
+            => new Squared<T>(Math.Min(s1.NumericValue, s2.NumericValue));
 
         public static Squared<T> Max(Squared<T> s1, Squared<T> s2)
-            => new Squared<T>(System.Math.Max(s1.NumericValue, s2.NumericValue));
+            => new Squared<T>(Math.Max(s1.NumericValue, s2.NumericValue));
 
         #endregion
     }

--- a/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
@@ -217,10 +217,10 @@ namespace Bearded.Utilities.SpaceTime
         #region static methods
 
         public static Acceleration Min(Acceleration s1, Acceleration s2)
-            => new Acceleration(System.Math.Min(s1.NumericValue, s2.NumericValue));
+            => new Acceleration(Math.Min(s1.NumericValue, s2.NumericValue));
 
         public static Acceleration Max(Acceleration s1, Acceleration s2)
-            => new Acceleration(System.Math.Max(s1.NumericValue, s2.NumericValue));
+            => new Acceleration(Math.Max(s1.NumericValue, s2.NumericValue));
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/undirected/Speed.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Speed.cs
@@ -230,10 +230,10 @@ namespace Bearded.Utilities.SpaceTime
         #region static methods
 
         public static Speed Min(Speed s1, Speed s2)
-            => new Speed(System.Math.Min(s1.NumericValue, s2.NumericValue));
+            => new Speed(Math.Min(s1.NumericValue, s2.NumericValue));
 
         public static Speed Max(Speed s1, Speed s2)
-            => new Speed(System.Math.Max(s1.NumericValue, s2.NumericValue));
+            => new Speed(Math.Max(s1.NumericValue, s2.NumericValue));
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/undirected/Unit.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Unit.cs
@@ -214,10 +214,10 @@ namespace Bearded.Utilities.SpaceTime
         #region static methods
 
         public static Unit Min(Unit u1, Unit u2)
-            => new Unit(System.Math.Min(u1.NumericValue, u2.NumericValue));
+            => new Unit(Math.Min(u1.NumericValue, u2.NumericValue));
 
         public static Unit Max(Unit u1, Unit u2)
-            => new Unit(System.Math.Max(u1.NumericValue, u2.NumericValue));
+            => new Unit(Math.Max(u1.NumericValue, u2.NumericValue));
 
         #endregion
 

--- a/Bearded.Utilities/Threading/ManualActionQueue.cs
+++ b/Bearded.Utilities/Threading/ManualActionQueue.cs
@@ -26,7 +26,7 @@ namespace Bearded.Utilities.Threading
         /// </summary>
         public void ExecuteOne()
         {
-            var action = this.actions.Take();
+            var action = actions.Take();
             action();
         }
 
@@ -38,7 +38,7 @@ namespace Bearded.Utilities.Threading
         public bool TryExecuteOne()
         {
             Action action;
-            if (this.actions.TryTake(out action))
+            if (actions.TryTake(out action))
             {
                 action();
                 return true;
@@ -55,7 +55,7 @@ namespace Bearded.Utilities.Threading
         public bool TryExecuteOne(TimeSpan timeout)
         {
             Action action;
-            if (this.actions.TryTake(out action, timeout))
+            if (actions.TryTake(out action, timeout))
             {
                 action();
                 return true;
@@ -80,7 +80,7 @@ namespace Bearded.Utilities.Threading
                 Action action;
                 if (timeLeft < new TimeSpan(0))
                     break;
-                if (!this.actions.TryTake(out action, timeLeft))
+                if (!actions.TryTake(out action, timeLeft))
                     break;
                 executed++;
                 action();
@@ -98,7 +98,7 @@ namespace Bearded.Utilities.Threading
         /// <param name="action">The action to run.</param>
         public void RunAndForget(Action action)
         {
-            this.actions.Add(action);
+            actions.Add(action);
         }
 
         /// <summary>
@@ -109,7 +109,7 @@ namespace Bearded.Utilities.Threading
         {
             var reset = new ManualResetEvent(false);
 
-            this.actions.Add(() =>
+            actions.Add(() =>
             {
                 action();
                 reset.Set();
@@ -125,7 +125,7 @@ namespace Bearded.Utilities.Threading
         public T RunAndReturn<T>(Func<T> action)
         {
             T ret = default;
-            this.RunAndAwait(() => ret = action());
+            RunAndAwait(() => ret = action());
             return ret;
         }
 
@@ -136,7 +136,7 @@ namespace Bearded.Utilities.Threading
         /// <param name="p0">The argument for calling the function.</param>
         public T RunAndReturn<TP0, T>(Func<TP0, T> action, TP0 p0)
         {
-            return this.RunAndReturn(() => action(p0));
+            return RunAndReturn(() => action(p0));
         }
 
         /// <summary>
@@ -147,7 +147,7 @@ namespace Bearded.Utilities.Threading
         /// <param name="p1">The second argument for calling the function.</param>
         public T RunAndReturn<TP0, TP1, T>(Func<TP0, TP1, T> action, TP0 p0, TP1 p1)
         {
-            return this.RunAndReturn(() => action(p0, p1));
+            return RunAndReturn(() => action(p0, p1));
         }
 
         /// <summary>
@@ -159,7 +159,7 @@ namespace Bearded.Utilities.Threading
         /// <param name="p2">The third argument for calling the function.</param>
         public T RunAndReturn<TP0, TP1, TP2, T>(Func<TP0, TP1, TP2, T> action, TP0 p0, TP1 p1, TP2 p2)
         {
-            return this.RunAndReturn(() => action(p0, p1, p2));
+            return RunAndReturn(() => action(p0, p1, p2));
         }
 
         /// <summary>
@@ -172,7 +172,7 @@ namespace Bearded.Utilities.Threading
         /// <param name="p3">The fourth argument for calling the function.</param>
         public T RunAndReturn<TP0, TP1, TP2, TP3, T>(Func<TP0, TP1, TP2, TP3, T> action, TP0 p0, TP1 p1, TP2 p2, TP3 p3)
         {
-            return this.RunAndReturn(() => action(p0, p1, p2, p3));
+            return RunAndReturn(() => action(p0, p1, p2, p3));
         }
 
         #endregion

--- a/Bearded.Utilities/Tilemaps/Rectangular/Extensions.cs
+++ b/Bearded.Utilities/Tilemaps/Rectangular/Extensions.cs
@@ -83,7 +83,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public static Direction Octagonal(this Direction2 direction)
         {
-            return (Direction)((int)System.Math.Floor(direction.Degrees * (1 / 45f) + 0.5f) % 8 + 1);
+            return (Direction)((int)Math.Floor(direction.Degrees * (1 / 45f) + 0.5f) % 8 + 1);
         }
 
         /// <summary>
@@ -92,7 +92,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         public static Direction Quadrogonal(this Direction2 direction)
         {
             return (Direction)((
-                (int)System.Math.Floor(direction.Degrees * (1 / 90f) + 0.5f) % 4
+                (int)Math.Floor(direction.Degrees * (1 / 90f) + 0.5f) % 4
                 ) * 2 + 1);
         }
 

--- a/Bearded.Utilities/Tilemaps/Rectangular/Tile.cs
+++ b/Bearded.Utilities/Tilemaps/Rectangular/Tile.cs
@@ -36,24 +36,24 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// <summary>
         /// X location of the tile.
         /// </summary>
-        public int X { get { return this.x; } }
+        public int X { get { return x; } }
 
         /// <summary>
         /// Y location of the tile.
         /// </summary>
-        public int Y { get { return this.y; } }
+        public int Y { get { return y; } }
 
         /// <summary>
         /// The data contained in the tile. Will throw if <see cref="IsValid"/> is false.
         /// </summary>
-        public TTileValue Value { get { return this.tilemap[this.X, this.Y]; } }
+        public TTileValue Value { get { return tilemap[X, Y]; } }
 
         /// <summary>
         /// True if the tile is located within its tilemap. False otherwise.
         /// </summary>
         public bool IsValid
         {
-            get { return this.tilemap != null && this.tilemap.IsValidTile(this); }
+            get { return tilemap != null && tilemap.IsValidTile(this); }
         }
 
         /// <summary>
@@ -65,7 +65,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
             {
                 for (int i = 1; i < 9; i++)
                 {
-                    var tile = this.Neighbour(Extensions.DirectionDeltas[i]);
+                    var tile = Neighbour(Extensions.DirectionDeltas[i]);
                     if (tile.IsValid)
                         yield return tile;
                 }
@@ -81,7 +81,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
             {
                 for (int i = 1; i < 9; i++)
                 {
-                    yield return this.Neighbour(Extensions.DirectionDeltas[i]);
+                    yield return Neighbour(Extensions.DirectionDeltas[i]);
                 }
             }
         }
@@ -95,15 +95,15 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public Tile<TTileValue> Neighbour(Direction direction)
         {
-            return this.Neighbour(direction.Step());
+            return Neighbour(direction.Step());
         }
 
         internal Tile<TTileValue> Neighbour(Step step)
         {
             return new Tile<TTileValue>(
-                this.tilemap,
-                this.x + step.X,
-                this.y + step.Y
+                tilemap,
+                x + step.X,
+                y + step.Y
                 );
         }
 
@@ -116,7 +116,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public bool Equals(Tile<TTileValue> other)
         {
-            return this.x == other.x && this.y == other.y && this.tilemap == other.tilemap;
+            return x == other.x && y == other.y && tilemap == other.tilemap;
         }
 
         /// <summary>
@@ -126,7 +126,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         {
             if (ReferenceEquals(null, obj))
                 return false;
-            return obj is Tile<TTileValue> && this.Equals((Tile<TTileValue>)obj);
+            return obj is Tile<TTileValue> && Equals((Tile<TTileValue>)obj);
         }
 
         /// <summary>
@@ -136,9 +136,9 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         {
             unchecked
             {
-                var hashCode = (this.tilemap != null ? this.tilemap.GetHashCode() : 0);
-                hashCode = (hashCode * 397) ^ this.x;
-                hashCode = (hashCode * 397) ^ this.y;
+                var hashCode = (tilemap != null ? tilemap.GetHashCode() : 0);
+                hashCode = (hashCode * 397) ^ x;
+                hashCode = (hashCode * 397) ^ y;
                 return hashCode;
             }
         }

--- a/Bearded.Utilities/Tilemaps/Rectangular/Tilemap.cs
+++ b/Bearded.Utilities/Tilemaps/Rectangular/Tilemap.cs
@@ -23,7 +23,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         {
             this.width = width;
             this.height = height;
-            this.tiles = new TTileValue[width, height];
+            tiles = new TTileValue[width, height];
         }
 
         #region properties
@@ -33,7 +33,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public int Width
         {
-            get { return this.width; }
+            get { return width; }
         }
 
         /// <summary>
@@ -41,7 +41,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public int Height
         {
-            get { return this.height; }
+            get { return height; }
         }
 
         /// <summary>
@@ -49,7 +49,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public int Count
         {
-            get { return this.width * this.height; }
+            get { return width * height; }
         }
 
         #endregion
@@ -63,8 +63,8 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// <param name="y">The Y location of the tile.</param>
         public TTileValue this[int x, int y]
         {
-            get { return this.tiles[x, y]; }
-            set { this.tiles[x, y] = value; }
+            get { return tiles[x, y]; }
+            set { tiles[x, y] = value; }
         }
 
         /// <summary>
@@ -88,8 +88,8 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// <param name="y">The Y location of the tile.</param>
         public bool IsValidTile(int x, int y)
         {
-            return x >= 0 && x < this.width
-                && y >= 0 && y < this.height;
+            return x >= 0 && x < width
+                && y >= 0 && y < height;
         }
 
         /// <summary>
@@ -97,7 +97,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public bool IsValidTile(Tile<TTileValue> tile)
         {
-            return this.IsValidTile(tile.X, tile.Y);
+            return IsValidTile(tile.X, tile.Y);
         }
 
         #endregion
@@ -109,8 +109,8 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         public IEnumerator<Tile<TTileValue>> GetEnumerator()
         {
-            for (int y = 0; y < this.height; y++)
-                for (int x = 0; x < this.width; x++)
+            for (int y = 0; y < height; y++)
+                for (int x = 0; x < width; x++)
                 {
                     yield return new Tile<TTileValue>(this, x, y);
                 }
@@ -121,7 +121,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// </summary>
         IEnumerator IEnumerable.GetEnumerator()
         {
-            return this.GetEnumerator();
+            return GetEnumerator();
         }
 
         #endregion


### PR DESCRIPTION

## ✨ What's this?
In an effort to get to 0 warnings, I removed a great number of redundant quantifiers, mostly `System` namespaces and `this.`. There's also some empty line removal.

## 🔍 Why do we want this?
Warnings are bad, and with all these small ones it's easy to miss more important things.

## 🏗 How is it done?
ALT+ENTER

### 💥 Breaking changes
None whatsoever. A purely cosmetic change.

## 💡 Review hints
Just scroll through the previous version in the diff viewer and you'll see that it's all removal of meaningless clutter.
