### PR TITLE
🧓 Deprecate Mathf

### DIFF
--- a/Bearded.Utilities/Core/MathConstants.cs
+++ b/Bearded.Utilities/Core/MathConstants.cs
@@ -1,0 +1,42 @@
+using System;
+
+namespace Bearded.Utilities
+{
+    public static class MathConstants
+    {
+        /// <summary>
+        /// Represents the square root of 2 (1.414213f).
+        /// </summary>
+        public const float Sqrt2 = 1.414213f;
+
+        /// <summary>
+        /// Represents the square root of 3 (1.732051f).
+        /// </summary>
+        public const float Sqrt3 = 1.732051f;
+
+        /// <summary>
+        /// Represents the value of pi (3.14159274).
+        /// </summary>
+        public const float Pi = MathF.PI;
+
+        /// <summary>
+        /// Represents the value of pi divided by two (1.57079637).
+        /// </summary>
+        public const float PiOver2 = Pi / 2.0f;
+
+        /// <summary>
+        /// Represents the value of pi divided by four (0.7853982).
+        /// </summary>
+        public const float PiOver4 = Pi / 4.0f;
+
+        /// <summary>
+        /// Represents the value of pi times two (6.28318548).
+        /// </summary>
+        public const float TwoPi = 2 * Pi;
+
+        /// <summary>
+        /// Represents the value of tau (6.28318548).
+        /// </summary>
+        public const float Tau = 2 * Pi;
+    }
+}

--- a/Bearded.Utilities/Core/Mathf.cs
+++ b/Bearded.Utilities/Core/Mathf.cs
@@ -1,117 +1,138 @@
 ﻿
+using System;
+
 namespace Bearded.Utilities
 {
     /// <summary>
     /// Collection of math-related functions.
     /// </summary>
+    [Obsolete]
     public static class Mathf
     {
         /// <summary>
         /// Represents the square root of 2 (1.414213f).
         /// </summary>
-        public const float Sqrt2 = 1.414213f;
+        [Obsolete("Use MathConstants instead")]
+        public const float Sqrt2 = MathConstants.Sqrt2;
 
         /// <summary>
         /// Represents the square root of 3 (1.732051f).
         /// </summary>
-        public const float Sqrt3 = 1.732051f;
+        [Obsolete("Use MathConstants instead")]
+        public const float Sqrt3 = MathConstants.Sqrt3;
 
         /// <summary>
         /// Represents the value of pi (3.14159274).
         /// </summary>
-        public const float Pi = (float)System.Math.PI;
+        [Obsolete("Use MathConstants instead")]
+        public const float Pi = MathConstants.Pi;
 
         /// <summary>
         /// Represents the value of pi divided by two (1.57079637).
         /// </summary>
-        public const float PiOver2 = Pi / 2.0f;
+        [Obsolete("Use MathConstants instead")]
+        public const float PiOver2 = MathConstants.PiOver2;
 
         /// <summary>
         /// Represents the value of pi divided by four (0.7853982).
         /// </summary>
-        public const float PiOver4 = Pi / 4.0f;
+        [Obsolete("Use MathConstants instead")]
+        public const float PiOver4 = MathConstants.PiOver4;
 
         /// <summary>
         /// Represents the value of pi times two (6.28318548).
         /// </summary>
-        public const float TwoPi = 2 * Pi;
+        [Obsolete("Use MathConstants instead")]
+        public const float TwoPi = MathConstants.TwoPi;
 
         /// <summary>
         /// Represents the value of tau (6.28318548).
         /// </summary>
-        public const float Tau = 2 * Pi;
-
-        private const float degreesToRadians = TwoPi / 360f;
-        private const float radiansToDegrees = 360f / TwoPi;
+        [Obsolete("Use MathConstants instead")]
+        public const float Tau = MathConstants.Tau;
 
         /// <summary>
         /// Returns the cosine of the specified angle.
         /// </summary>
-        public static float Cos(float f) => (float)System.Math.Cos(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Cos(float f) => MathF.Cos(f);
 
         /// <summary>
         /// Returns the sine of the specified angle.
         /// </summary>
-        public static float Sin(float f) => (float)System.Math.Sin(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Sin(float f) => MathF.Sin(f);
 
         /// <summary>
         /// Returns the tangent of the specified angle.
         /// </summary>
-        public static float Tan(float f) => (float)System.Math.Tan(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Tan(float f) => MathF.Tan(f);
 
         /// <summary>
         /// Returns the angle whose cosine is the specified number.
         /// </summary>
-        public static float Acos(float f) => (float)System.Math.Acos(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Acos(float f) => MathF.Acos(f);
 
         /// <summary>
         /// Returns the angle whose sine is the specified number.
         /// </summary>
-        public static float Asin(float f) => (float)System.Math.Asin(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Asin(float f) => MathF.Asin(f);
 
         /// <summary>
         /// Returns the angle whose tangent is the specified number.
         /// </summary>
-        public static float Atan(float f) => (float)System.Math.Atan(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Atan(float f) => MathF.Atan(f);
 
         /// <summary>
         /// Returns the angle whose tangent is the quotient of two specified numbers.
         /// </summary>
-        public static float Atan2(float y, float x) => (float)System.Math.Atan2(y, x);
+        [Obsolete("Use System.MathF instead")]
+        public static float Atan2(float y, float x) => MathF.Atan2(y, x);
 
         /// <summary>
         /// Returns the square root of the specified number.
         /// </summary>
-        public static float Sqrt(float f) => (float)System.Math.Sqrt(f);
+        [Obsolete("Use System.MathF instead")]
+        public static float Sqrt(float f) => MathF.Sqrt(f);
 
         /// <summary>
         /// Returns a specified number raised to the specified power.
         /// </summary>
-        public static float Pow(float b, float power) => (float)System.Math.Pow(b, power);
+        [Obsolete("Use System.MathF instead")]
+        public static float Pow(float b, float power) => MathF.Pow(b, power);
 
         /// <summary>
         /// Returns the lowest integral number higher than or equal to the specified number.
         /// </summary>
-        public static int CeilToInt(double d) => (int)System.Math.Ceiling(d);
+        [Obsolete("Use MoreMath instead")]
+        public static int CeilToInt(double d) => MoreMath.CeilToInt(d);
 
         /// <summary>
         /// Returns the highest integral number lower than or equal to the specified number.
         /// </summary>
-        public static int FloorToInt(double d) => (int)System.Math.Floor(d);
+        [Obsolete("Use MoreMath instead")]
+        public static int FloorToInt(double d) => MoreMath.FloorToInt(d);
 
         /// <summary>
         /// Returns the integral number closest to the specified number.
         /// </summary>
-        public static int RoundToInt(double d) => (int)System.Math.Round(d);
+        [Obsolete("Use MoreMath instead")]
+        public static int RoundToInt(double d) => MoreMath.RoundToInt(d);
 
         /// <summary>
         /// Converts an angle in radians to degrees.
         /// </summary>
-        public static float RadiansToDegrees(float radians) => radians * radiansToDegrees;
+        [Obsolete("Use MoreMath instead")]
+        public static float RadiansToDegrees(float radians) => MoreMath.RadiansToDegrees(radians);
 
         /// <summary>
         /// Converts an angle in degrees to radians.
         /// </summary>
-        public static float DegreesToRadians(float degrees) => degrees * degreesToRadians;
+        [Obsolete("Use MoreMath instead")]
+        public static float DegreesToRadians(float degrees) => MoreMath.DegreesToRadians(degrees);
     }
 }

--- a/Bearded.Utilities/Core/MoreMath.cs
+++ b/Bearded.Utilities/Core/MoreMath.cs
@@ -1,0 +1,45 @@
+using System;
+
+namespace Bearded.Utilities
+{
+    public static class MoreMath
+    {
+        private const double degreesToRadians = Math.PI / 180;
+        private const double radiansToDegrees = 180 / Math.PI;
+
+        /// <summary>
+        /// Returns the lowest integral number higher than or equal to the specified number.
+        /// </summary>
+        public static int CeilToInt(double d) => (int)Math.Ceiling(d);
+
+        /// <summary>
+        /// Returns the highest integral number lower than or equal to the specified number.
+        /// </summary>
+        public static int FloorToInt(double d) => (int)Math.Floor(d);
+
+        /// <summary>
+        /// Returns the integral number closest to the specified number.
+        /// </summary>
+        public static int RoundToInt(double d) => (int)Math.Round(d);
+
+        /// <summary>
+        /// Converts an angle in radians to degrees.
+        /// </summary>
+        public static float RadiansToDegrees(float radians) => radians * (float) radiansToDegrees;
+
+        /// <summary>
+        /// Converts an angle in radians to degrees.
+        /// </summary>
+        public static double RadiansToDegrees(double radians) => radians * radiansToDegrees;
+
+        /// <summary>
+        /// Converts an angle in degrees to radians.
+        /// </summary>
+        public static float DegreesToRadians(float degrees) => degrees * (float) degreesToRadians;
+
+        /// <summary>
+        /// Converts an angle in degrees to radians.
+        /// </summary>
+        public static double DegreesToRadians(double degrees) => degrees * degreesToRadians;
+    }
+}

--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -31,7 +31,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Angle FromDegrees(float degrees)
         {
-            return new Angle(Mathf.DegreesToRadians(degrees));
+            return new Angle(MoreMath.DegreesToRadians(degrees));
         }
 
         /// <summary>
@@ -42,7 +42,7 @@ namespace Bearded.Utilities.Geometry
         {
             float perpDot = from.Y * to.X - from.X * to.Y;
 
-            return FromRadians(Mathf.Atan2(perpDot, Vector2.Dot(from, to)));
+            return FromRadians(MathF.Atan2(perpDot, Vector2.Dot(from, to)));
         }
 
         /// <summary>
@@ -62,7 +62,7 @@ namespace Bearded.Utilities.Geometry
         {
             var a = Between(from, to);
             if (a.radians < 0)
-                a += Mathf.TwoPi.Radians();
+                a += MathConstants.TwoPi.Radians();
             return a;
         }
 
@@ -74,7 +74,7 @@ namespace Bearded.Utilities.Geometry
         {
             var a = Between(from, to);
             if (a.radians > 0)
-                a -= Mathf.TwoPi.Radians();
+                a -= MathConstants.TwoPi.Radians();
             return a;
         }
 
@@ -99,7 +99,7 @@ namespace Bearded.Utilities.Geometry
         /// <summary>
         /// Gets the value of the angle in degrees.
         /// </summary>
-        public float Degrees => Mathf.RadiansToDegrees(radians);
+        public float Degrees => MoreMath.RadiansToDegrees(radians);
 
         /// <summary>
         /// Gets a 2x2 rotation matrix that rotates vectors by this angle.
@@ -127,21 +127,21 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public float Sin()
         {
-            return Mathf.Sin(radians);
+            return MathF.Sin(radians);
         }
         /// <summary>
         /// Returns the Cosine of the angle.
         /// </summary>
         public float Cos()
         {
-            return Mathf.Cos(radians);
+            return MathF.Cos(radians);
         }
         /// <summary>
         /// Returns the Tangent of the angle.
         /// </summary>
         public float Tan()
         {
-            return Mathf.Tan(radians);
+            return MathF.Tan(radians);
         }
         /// <summary>
         /// Returns the Sign of the angle.

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -11,8 +11,8 @@ namespace Bearded.Utilities.Geometry
     {
         private const long numSteps = (1L << 32);
 
-        private const float fromRadians = numSteps / Mathf.TwoPi;
-        private const float toRadians = Mathf.TwoPi / numSteps;
+        private const float fromRadians = numSteps / MathConstants.TwoPi;
+        private const float toRadians = MathConstants.TwoPi / numSteps;
 
         private const float fromDegrees = numSteps / 360f;
         private const float toDegrees = 360f / numSteps;
@@ -47,7 +47,7 @@ namespace Bearded.Utilities.Geometry
         /// </summary>
         public static Direction2 Of(Vector2 vector)
         {
-            return FromRadians(Mathf.Atan2(vector.Y, vector.X));
+            return FromRadians(MathF.Atan2(vector.Y, vector.X));
         }
 
         /// <summary>
@@ -103,7 +103,7 @@ namespace Bearded.Utilities.Geometry
             get
             {
                 var radians = Radians;
-                return new Vector2(Mathf.Cos(radians), Mathf.Sin(radians));
+                return new Vector2(MathF.Cos(radians), MathF.Sin(radians));
             }
         }
 

--- a/Bearded.Utilities/Input/InputManager.cs
+++ b/Bearded.Utilities/Input/InputManager.cs
@@ -61,7 +61,7 @@ namespace Bearded.Utilities.Input
         }
 
         public Vector2 MousePosition { get; private set; }
-        public int DeltaScroll => Mathf.RoundToInt(DeltaScrollF);
+        public int DeltaScroll => MoreMath.RoundToInt(DeltaScrollF);
         public float DeltaScrollF => mouseEvents.DeltaScrollF;
 
         public bool MouseMoved => mouseState.Delta.LengthSquared != 0;

--- a/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
@@ -31,7 +31,8 @@ namespace Bearded.Utilities.SpaceTime
         /// <summary>
         /// Creates a new instance of the AngularAcceleration type from an angle in degrees.
         /// </summary>
-        public static AngularAcceleration FromDegrees(float degrees) => new AngularAcceleration(Mathf.DegreesToRadians(degrees));
+        public static AngularAcceleration FromDegrees(float degrees) =>
+            new AngularAcceleration(MoreMath.DegreesToRadians(degrees));
 
         #endregion
 
@@ -72,7 +73,7 @@ namespace Bearded.Utilities.SpaceTime
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
         public string ToString(string format, IFormatProvider formatProvider)
-            => $"{Mathf.RadiansToDegrees(value).ToString(format, formatProvider)} °/t²";
+            => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t²";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
@@ -31,7 +31,8 @@ namespace Bearded.Utilities.SpaceTime
         /// <summary>
         /// Creates a new instance of the AngularVelocity type from an angle in degrees.
         /// </summary>
-        public static AngularVelocity FromDegrees(float degrees) => new AngularVelocity(Mathf.DegreesToRadians(degrees));
+        public static AngularVelocity FromDegrees(float degrees) =>
+            new AngularVelocity(MoreMath.DegreesToRadians(degrees));
 
         #endregion
 
@@ -72,7 +73,7 @@ namespace Bearded.Utilities.SpaceTime
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
         public string ToString(string format, IFormatProvider formatProvider)
-            => $"{Mathf.RadiansToDegrees(value).ToString(format, formatProvider)} °/t";
+            => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t";
 
         #endregion
 


### PR DESCRIPTION
## ✨ What's this?
This PR deprecates the `Mathf` class in favour of other classes.

### 🔗 Relationships
Ref #201 

## 🔍 Why do we want this?
.NET Core includes a `System.MathF` class which contains a copy of all math functions for floats. `Mathf` was originally introduced with this purpose, but is now obsolete. This is why this PR deprecates the class in favour of the standard System one, which is much more complete.

## 🏗 How is it done?
All existing functions on `Mathf`, including the class itself, is marked as obsolete to give time to migrate to the new functionality.

Not all functionality on `Mathf` actually mirrors `Math`. In my opinion, this means it had already grown beyond its original purpose. The remaining functionality is split out in `MathConstants`, providing a much tighter responsibility, and `MoreMath`, containing functionality that I couldn't place anywhere else.

### 💥 Breaking changes
No breaking changes at this time, unless people treat obsolete warnings as errors.

### 🔬 Why not another way?
I believe this is the correct separation of concerns.

### 🦋 Side effects
`Mathf` will have to be truly and really deleted in a future PR.

## 💡 Review hints
None of the code should be new.