### PR TITLE
👷‍♂️ Add GitHub actions work flow for building/testing and releasing

### DIFF
--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -1,0 +1,25 @@
+name: .NET Core
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup .NET Core
+      uses: actions/setup-dotnet@v1
+      with:
+        dotnet-version: 3.1.301
+    - name: Install dependencies
+      run: dotnet restore
+    - name: Build
+      run: dotnet build --configuration Release --no-restore
+    - name: Test
+      run: dotnet test --no-restore --verbosity normal

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --no-restore
       - name: Test
-        run: dotnet test --no-build --verbosity normal
+        run: dotnet test --no-restore --verbosity normal
   
   release:
     
@@ -38,7 +38,7 @@ jobs:
       - name: Extract version number
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Pack binary
-        run: dotnet pack --no-build -p:PackageVersion=${{ env.RELEASE_VERSION }}
+        run: dotnet pack --no-restore -p:PackageVersion=${{ env.RELEASE_VERSION }}
       - name: Create a Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -38,7 +38,7 @@ jobs:
       - name: Extract version number
         run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
       - name: Pack binary
-        run: dotnet pack --no-restore -p:PackageVersion=${{ env.RELEASE_VERSION }}
+        run: dotnet pack --no-restore -p:PackageVersion=${RELEASE_VERSION:1}
       - name: Create a Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/dotnet-core.yml
+++ b/.github/workflows/dotnet-core.yml
@@ -3,23 +3,53 @@ name: .NET Core
 on:
   push:
     branches: [ master ]
+    tags: 
+      - v*
   pull_request:
     branches: [ master ]
 
 jobs:
   build:
 
+    name: Build and test
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
-    - name: Setup .NET Core
-      uses: actions/setup-dotnet@v1
-      with:
-        dotnet-version: 3.1.301
-    - name: Install dependencies
-      run: dotnet restore
-    - name: Build
-      run: dotnet build --configuration Release --no-restore
-    - name: Test
-      run: dotnet test --no-restore --verbosity normal
+      - uses: actions/checkout@v2
+      - name: Setup .NET Core
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 3.1.301
+      - name: Install dependencies
+        run: dotnet restore
+      - name: Build
+        run: dotnet build --configuration Release --no-restore
+      - name: Test
+        run: dotnet test --no-build --verbosity normal
+  
+  release:
+    
+    name: Pack and release
+    runs-on: ubuntu-latest
+    needs: build
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/')
+
+    steps:
+      - name: Extract version number
+        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
+      - name: Pack binary
+        run: dotnet pack --no-build -p:PackageVersion=${{ env.RELEASE_VERSION }}
+      - name: Create a Release
+        id: create_release
+        uses: actions/create-release@v1
+        with:
+          tag_name: ${{ env.RELEASE_VERSION }}
+          release_name: Release ${{ env.RELEASE_VERSION }}
+          draft: false
+          prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
+      - name: Push release to NuGet
+        run: dotnet nuget push *.nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+      - name: Push release to GitHub
+        run: dotnet nuget push *.nupkg --skip-duplicate
+        env:
+          NUGET_AUTH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
This PR adds a GitHub actions config.

It's based on the default template as provided by GitHub, from which I then built a release flow as well.

This flow will automatically build and test on every PR and master branch bunch (see the example in this PR).

When a tag is pushed to the default branch, it will:

* Execute the normal "build" job as if it is a normal push (this generates the necessary binary files, and also makes sure the tests are still passing)
* Package the nupkg files
* Upload the nupkg files to NuGet using an API token. The API token has to be stored as a secret in the organisation.
* Upload the nupkg files to GitHub packages. This uses the default GitHub secret token.
* Create a GitHub release. We currently don't attach any custom assets to this release, since there isn't a way to fetch all the nupkg files using a file glob.