### PR TITLE
0️⃣ Fix override nullability

### DIFF
--- a/Bearded.Utilities/Core/Id.cs
+++ b/Bearded.Utilities/Core/Id.cs
@@ -19,7 +19,7 @@ namespace Bearded.Utilities
         public override string ToString() => $"{typeof(T).Name}:{Value}";
         public override int GetHashCode() => Value.GetHashCode();
         public bool Equals(Id<T> other) => Value.Equals(other.Value);
-        public override bool Equals(object obj) => obj is Id<T> id && Equals(id);
+        public override bool Equals(object? obj) => obj is Id<T> id && Equals(id);
         public static bool operator ==(Id<T> left, Id<T> right) => left.Equals(right);
         public static bool operator !=(Id<T> left, Id<T> right) => !(left == right);
     }

--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -64,7 +64,7 @@ namespace Bearded.Utilities
         public bool Equals(Maybe<T> other) =>
             hasValue == other.hasValue && EqualityComparer<T>.Default.Equals(value, other.value);
 
-        public override bool Equals(object obj) => obj is Maybe<T> other && Equals(other);
+        public override bool Equals(object? obj) => obj is Maybe<T> other && Equals(other);
 
         public override int GetHashCode() => hasValue ? EqualityComparer<T>.Default.GetHashCode(value) : 0;
 

--- a/Bearded.Utilities/Core/Void.cs
+++ b/Bearded.Utilities/Core/Void.cs
@@ -8,7 +8,7 @@ namespace Bearded.Utilities
 
         public int CompareTo(Void _) => 0;
         public bool Equals(Void _) => true;
-        public override bool Equals(object obj) => obj is Void;
+        public override bool Equals(object? obj) => obj is Void;
         public override int GetHashCode() => 0;
 
         // ReSharper disable UnusedParameter.Global

--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -288,7 +288,7 @@ namespace Bearded.Utilities.Geometry
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object"/> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
 			return obj is Angle && Equals((Angle)obj);
         }
@@ -355,7 +355,7 @@ namespace Bearded.Utilities.Geometry
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{Degrees.ToString(format, formatProvider)}°";
 
         #endregion

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -214,7 +214,7 @@ namespace Bearded.Utilities.Geometry
         /// <returns>
         ///   <c>true</c> if the specified <see cref="System.Object" /> is equal to this instance; otherwise, <c>false</c>.
         /// </returns>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             return obj is Direction2 && Equals((Direction2)obj);
         }
@@ -252,7 +252,7 @@ namespace Bearded.Utilities.Geometry
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{Radians.ToString(format, formatProvider)} rad";
 
         #endregion

--- a/Bearded.Utilities/Geometry/PolarPosition.cs
+++ b/Bearded.Utilities/Geometry/PolarPosition.cs
@@ -83,7 +83,7 @@ namespace Bearded.Utilities.Geometry
         /// true if <paramref name="obj"/> and this instance are the same type and represent the same value; otherwise, false.
         /// </returns>
         /// <param name="obj">Another object to compare to. </param><filterpriority>2</filterpriority>
-        public override bool Equals(object obj) => base.Equals(obj);
+        public override bool Equals(object? obj) => base.Equals(obj);
 
         /// <summary>
         /// Returns the hash code for this instance.
@@ -106,7 +106,7 @@ namespace Bearded.Utilities.Geometry
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{R.ToString(format, formatProvider)} ∠{Angle.ToString(format, formatProvider)}";
 
         #endregion

--- a/Bearded.Utilities/Geometry/Rectangle.cs
+++ b/Bearded.Utilities/Geometry/Rectangle.cs
@@ -66,7 +66,7 @@ namespace Bearded.Utilities.Geometry
             => Left == other.Left && Right == other.Right && Width == other.Width && Height == other.Height;
             // ReSharper restore CompareOfFloatsByEqualityOperator
 
-        public override bool Equals(object obj) => obj is Rectangle && Equals((Rectangle) obj);
+        public override bool Equals(object? obj) => obj is Rectangle && Equals((Rectangle) obj);
 
         public override int GetHashCode()
         {
@@ -82,7 +82,7 @@ namespace Bearded.Utilities.Geometry
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"[{Left.ToString(format, formatProvider)}, {Top.ToString(format, formatProvider)} x " +
                $"[{Right.ToString(format, formatProvider)}, {Bottom.ToString(format, formatProvider)}";
 

--- a/Bearded.Utilities/IO/Logger.cs
+++ b/Bearded.Utilities/IO/Logger.cs
@@ -135,7 +135,7 @@ namespace Bearded.Utilities.IO
             public bool Equals(Entry other)
                 => string.Equals(Text, other.Text) && Severity == other.Severity && Time.Equals(other.Time);
 
-            public override bool Equals(object obj) => obj is Entry entry && Equals(entry);
+            public override bool Equals(object? obj) => obj is Entry entry && Equals(entry);
 
             public override int GetHashCode()
             {

--- a/Bearded.Utilities/Input/Actions/DigitalAction.cs
+++ b/Bearded.Utilities/Input/Actions/DigitalAction.cs
@@ -9,7 +9,7 @@ namespace Bearded.Utilities.Input.Actions
         public bool IsAnalog => false;
         public float AnalogAmount => Active ? 1 : 0;
 
-        public override bool Equals(object obj) => Equals(obj as IAction);
+        public override bool Equals(object? obj) => Equals(obj as IAction);
         public bool Equals(IAction other) => other is DigitalAction && this.IsSameAs(other);
         public override int GetHashCode() => ToString()?.GetHashCode() ?? 0;
     }

--- a/Bearded.Utilities/Input/Actions/DummyAction.cs
+++ b/Bearded.Utilities/Input/Actions/DummyAction.cs
@@ -17,7 +17,7 @@ namespace Bearded.Utilities.Input.Actions
 
         public override string ToString() => name;
 
-        public override bool Equals(object obj) => Equals(obj as IAction);
+        public override bool Equals(object? obj) => Equals(obj as IAction);
         public bool Equals(IAction other) => other is DummyAction && this.IsSameAs(other);
         public override int GetHashCode() => ToString().GetHashCode();
     }

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -121,7 +121,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Acceleration2 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Acceleration2 && Equals((Acceleration2)obj);
+        public override bool Equals(object? obj) => obj is Acceleration2 && Equals((Acceleration2)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -131,7 +131,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t²";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -121,7 +121,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Difference2 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Difference2 && Equals((Difference2)obj);
+        public override bool Equals(object? obj) => obj is Difference2 && Equals((Difference2)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -131,7 +131,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -75,7 +75,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Position2 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Position2 && Equals((Position2)obj);
+        public override bool Equals(object? obj) => obj is Position2 && Equals((Position2)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -85,7 +85,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -121,7 +121,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Velocity2 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Velocity2 && Equals((Velocity2)obj);
+        public override bool Equals(object? obj) => obj is Velocity2 && Equals((Velocity2)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -131,7 +131,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
@@ -113,7 +113,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Acceleration3 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Acceleration3 a && Equals(a);
+        public override bool Equals(object? obj) => obj is Acceleration3 a && Equals(a);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -123,7 +123,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider) => "(" +
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
                $"{value.X.ToString(format, formatProvider)}, " +
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u/t²";

--- a/Bearded.Utilities/SpaceTime/3d/Difference3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Difference3.cs
@@ -110,7 +110,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Difference3 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Difference3 diff && Equals(diff);
+        public override bool Equals(object? obj) => obj is Difference3 diff && Equals(diff);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -120,7 +120,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider) => "(" +
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
             $"{value.X.ToString(format, formatProvider)}, " +
             $"{value.Y.ToString(format, formatProvider)}, " +
             $"{value.Z.ToString(format, formatProvider)}) u";

--- a/Bearded.Utilities/SpaceTime/3d/Position3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Position3.cs
@@ -84,7 +84,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Position3 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Position3 pos && Equals(pos);
+        public override bool Equals(object? obj) => obj is Position3 pos && Equals(pos);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -94,7 +94,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider) => "(" +
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
                $"{value.X.ToString(format, formatProvider)}, " +
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u";

--- a/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
@@ -110,7 +110,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public bool Equals(Velocity3 other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Velocity3 v && Equals(v);
+        public override bool Equals(object? obj) => obj is Velocity3 v && Equals(v);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -120,7 +120,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider) => "(" +
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
                $"{value.X.ToString(format, formatProvider)}, " +
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u/t";

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -67,7 +67,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Squared<T> other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Squared<T> && Equals((Squared<T>)obj);
+        public override bool Equals(object? obj) => obj is Squared<T> && Equals((Squared<T>)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -83,7 +83,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"|{value.ToString(format, formatProvider)}|";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
@@ -62,7 +62,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(AngularAcceleration other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is AngularAcceleration && Equals((AngularAcceleration)obj);
+        public override bool Equals(object? obj) => obj is AngularAcceleration && Equals((AngularAcceleration)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -72,7 +72,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t²";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
@@ -62,7 +62,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(AngularVelocity other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is AngularVelocity && Equals((AngularVelocity)obj);
+        public override bool Equals(object? obj) => obj is AngularVelocity && Equals((AngularVelocity)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -72,7 +72,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/gravity/Mass.cs
+++ b/Bearded.Utilities/SpaceTime/gravity/Mass.cs
@@ -29,7 +29,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Mass other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Mass mass && Equals(mass);
+        public override bool Equals(object? obj) => obj is Mass mass && Equals(mass);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -39,7 +39,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} m";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/time/Frequency.cs
+++ b/Bearded.Utilities/SpaceTime/time/Frequency.cs
@@ -37,7 +37,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Frequency other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Frequency f && Equals(f);
+        public override bool Equals(object? obj) => obj is Frequency f && Equals(f);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -47,7 +47,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} 1/t";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/time/Instant.cs
+++ b/Bearded.Utilities/SpaceTime/time/Instant.cs
@@ -40,7 +40,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Instant other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Instant && Equals((Instant)obj);
+        public override bool Equals(object? obj) => obj is Instant && Equals((Instant)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -56,7 +56,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} t";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
+++ b/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
@@ -37,7 +37,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(TimeSpan other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is TimeSpan t && Equals(t);
+        public override bool Equals(object? obj) => obj is TimeSpan t && Equals(t);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -47,7 +47,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} t";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
@@ -52,7 +52,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Acceleration other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Acceleration && Equals((Acceleration)obj);
+        public override bool Equals(object? obj) => obj is Acceleration && Equals((Acceleration)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -62,7 +62,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} u/t²";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/undirected/Speed.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Speed.cs
@@ -52,7 +52,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Speed other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Speed && Equals((Speed)obj);
+        public override bool Equals(object? obj) => obj is Speed && Equals((Speed)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -68,7 +68,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} u/t";
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/undirected/Unit.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Unit.cs
@@ -52,7 +52,7 @@ namespace Bearded.Utilities.SpaceTime
         // ReSharper disable once CompareOfFloatsByEqualityOperator
         public bool Equals(Unit other) => value == other.value;
 
-        public override bool Equals(object obj) => obj is Unit && Equals((Unit)obj);
+        public override bool Equals(object? obj) => obj is Unit && Equals((Unit)obj);
 
         public override int GetHashCode() => value.GetHashCode();
 
@@ -68,7 +68,7 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string format, IFormatProvider formatProvider)
+        public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} u";
 
         #endregion

--- a/Bearded.Utilities/Tilemaps/Rectangular/Tile.cs
+++ b/Bearded.Utilities/Tilemaps/Rectangular/Tile.cs
@@ -122,7 +122,7 @@ namespace Bearded.Utilities.Tilemaps.Rectangular
         /// <summary>
         /// Indicates whether this instance and a specified object are equal.
         /// </summary>
-        public override bool Equals(object obj)
+        public override bool Equals(object? obj)
         {
             if (ReferenceEquals(null, obj))
                 return false;


### PR DESCRIPTION

## ✨ What's this?
This makes a bunch of parameters of overridden methods (i.e. Equals and ToString) nullable, to match their abstract/virtual counterpart.

### 🔗 Relationships

Ref #184

## 🔍 Why do we want this?
 This removes a great number of warnings which will become errors once we enable full nullablity errors.

### 💥 Breaking changes
As public interface changes go, this is pretty mild, but I suppose it could give someone warnings/errors if they relied on the specific previous implementations.

## 💡 Review hints
This is really trivial, please feel free to squash if there are no questions/concerns.
