### PR TITLE
🐛 Add missing GitHub token to release creation step

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -41,6 +41,8 @@ jobs:
       - name: Create a Release
         id: create_release
         uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
           release_name: Release ${{ env.RELEASE_VERSION }}


### PR DESCRIPTION
## ✨ What's this?
Fixes a bug with the publish GitHub action so that the create release step works.

### 🔗 Relationships
See #198 

## 🔍 Why do we want this?
To make the automatic publish workflow work.

## 🏗 How is it done?
It sets the correct token in the environment variable that the create-release action expects.

### 🔬 Why not another way?
This is the recommended way based on the example.

## 💡 Review hints
Should be trivial. Feel free the squash.