### PR TITLE
👷‍♂️ Use the GitHub token as key when authenticating

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -52,7 +52,6 @@ jobs:
       # Push the NuGet package to the package providers
       - name: Push release to NuGet
         run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+        
       - name: Push release to GitHub
-        run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/beardgame/index.json --skip-duplicate
-        env:
-          NUGET_AUTH_TOKEN: ${{ github.token }}
+        run: dotnet nuget push **/*.nupkg --source https://nuget.pkg.github.com/beardgame/index.json -k ${{ github.token }} --skip-duplicate


### PR DESCRIPTION
## ✨ What's this?
Final attempt at fixing the GitHub package push in our new actions.

### 🔗 Relationships
Ref #198 

## 🔍 Why do we want this?
This fixes the push to GitHub packages so we can use that as parallel publishing source.

## 🏗 How is it done?
It sets the authentication key to the GitHub authentication token.

## 💡 Review hints
Feel free to squash.
