### PR TITLE
🐛 Fix input handling by going back to our own snapshots

### DIFF
--- a/Bearded.Utilities/Core/AsyncAtomicUpdating.cs
+++ b/Bearded.Utilities/Core/AsyncAtomicUpdating.cs
@@ -1,13 +1,19 @@
 ﻿namespace Bearded.Utilities
 {
-    public class AsyncAtomicUpdating<T>
-        where T : struct
+    public sealed class AsyncAtomicUpdating<T>
     {
         private readonly object mutex = new object();
 
         public T Current { get; private set; }
         public T Previous { get; private set; }
         private T lastRecorded;
+
+        public AsyncAtomicUpdating(T initialState)
+        {
+            Current = initialState;
+            Previous = initialState;
+            lastRecorded = initialState;
+        }
 
         public void SetLastKnownState(T state)
         {
@@ -24,8 +30,6 @@
                 UpdateTo(lastRecorded);
             }
         }
-
-        public void UpdateToDefault() => UpdateTo(default);
 
         public void UpdateTo(T state)
         {


### PR DESCRIPTION
## ✨ What's this?
This PR restores the original implementation of the input manager with our own input state snapshots to ensure we only miss inputs if they happen within a frame.