### PR TITLE
🔠 Add format-only ToString to SpaceTime types

### DIFF
--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -358,6 +358,9 @@ namespace Bearded.Utilities.Geometry
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{Degrees.ToString(format, formatProvider)}°";
 
+        public string ToString(string? format)
+            => $"{Degrees.ToString(format)}°";
+
         #endregion
 
         #region Casts

--- a/Bearded.Utilities/Geometry/Angle.cs
+++ b/Bearded.Utilities/Geometry/Angle.cs
@@ -359,7 +359,7 @@ namespace Bearded.Utilities.Geometry
             => $"{Degrees.ToString(format, formatProvider)}°";
 
         public string ToString(string? format)
-            => $"{Degrees.ToString(format)}°";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -256,7 +256,7 @@ namespace Bearded.Utilities.Geometry
             => $"{Radians.ToString(format, formatProvider)} rad";
 
         public string ToString(string? format)
-            => $"{Radians.ToString(format)} rad";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/Geometry/Direction2.cs
+++ b/Bearded.Utilities/Geometry/Direction2.cs
@@ -255,6 +255,9 @@ namespace Bearded.Utilities.Geometry
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{Radians.ToString(format, formatProvider)} rad";
 
+        public string ToString(string? format)
+            => $"{Radians.ToString(format)} rad";
+
         #endregion
 
         #region Casts

--- a/Bearded.Utilities/Geometry/PolarPosition.cs
+++ b/Bearded.Utilities/Geometry/PolarPosition.cs
@@ -110,7 +110,7 @@ namespace Bearded.Utilities.Geometry
             => $"{R.ToString(format, formatProvider)} ∠{Angle.ToString(format, formatProvider)}";
 
         public string ToString(string? format)
-            => $"{R.ToString(format)} ∠{Angle.ToString(format)}";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/Geometry/PolarPosition.cs
+++ b/Bearded.Utilities/Geometry/PolarPosition.cs
@@ -109,6 +109,9 @@ namespace Bearded.Utilities.Geometry
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{R.ToString(format, formatProvider)} ∠{Angle.ToString(format, formatProvider)}";
 
+        public string ToString(string? format)
+            => $"{R.ToString(format)} ∠{Angle.ToString(format)}";
+
         #endregion
 
         #region Operator

--- a/Bearded.Utilities/Geometry/Rectangle.cs
+++ b/Bearded.Utilities/Geometry/Rectangle.cs
@@ -86,6 +86,10 @@ namespace Bearded.Utilities.Geometry
             => $"[{Left.ToString(format, formatProvider)}, {Top.ToString(format, formatProvider)} x " +
                $"[{Right.ToString(format, formatProvider)}, {Bottom.ToString(format, formatProvider)}";
 
+        public string ToString(string? format)
+            => $"[{Left.ToString(format)}, {Top.ToString(format)} x " +
+               $"[{Right.ToString(format)}, {Bottom.ToString(format)}";
+
         public static bool operator ==(Rectangle left, Rectangle right) => left.Equals(right);
         public static bool operator !=(Rectangle left, Rectangle right) => !left.Equals(right);
     }

--- a/Bearded.Utilities/Geometry/Rectangle.cs
+++ b/Bearded.Utilities/Geometry/Rectangle.cs
@@ -87,8 +87,7 @@ namespace Bearded.Utilities.Geometry
                $"[{Right.ToString(format, formatProvider)}, {Bottom.ToString(format, formatProvider)}";
 
         public string ToString(string? format)
-            => $"[{Left.ToString(format)}, {Top.ToString(format)} x " +
-               $"[{Right.ToString(format)}, {Bottom.ToString(format)}";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         public static bool operator ==(Rectangle left, Rectangle right) => left.Equals(right);
         public static bool operator !=(Rectangle left, Rectangle right) => !left.Equals(right);

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -131,13 +131,11 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
-            $"{value.X.ToString(format, formatProvider)}, " +
-            $"{value.Y.ToString(format, formatProvider)}) u/t²";
+        public string ToString(string? format, IFormatProvider? formatProvider)
+            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t²";
 
-        public string ToString(string? format) => "(" +
-            $"{value.X.ToString(format)}, " +
-            $"{value.Y.ToString(format)}) u/t²";
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t²";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -131,11 +131,13 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t²";
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
+            $"{value.X.ToString(format, formatProvider)}, " +
+            $"{value.Y.ToString(format, formatProvider)}) u/t²";
 
-        public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t²";
+        public string ToString(string? format) => "(" +
+            $"{value.X.ToString(format)}, " +
+            $"{value.Y.ToString(format)}) u/t²";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -135,7 +135,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t²";
 
         public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t²";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Acceleration2.cs
@@ -134,6 +134,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t²";
 
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t²";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -131,11 +131,13 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
+            $"{value.X.ToString(format, formatProvider)}, " +
+            $"{value.Y.ToString(format, formatProvider)}) u";
 
-        public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
+        public string ToString(string? format) => "(" +
+            $"{value.X.ToString(format)}, " +
+            $"{value.Y.ToString(format)}) u";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -131,13 +131,11 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
-            $"{value.X.ToString(format, formatProvider)}, " +
-            $"{value.Y.ToString(format, formatProvider)}) u";
+        public string ToString(string? format, IFormatProvider? formatProvider)
+            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
-        public string ToString(string? format) => "(" +
-            $"{value.X.ToString(format)}, " +
-            $"{value.Y.ToString(format)}) u";
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -135,7 +135,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
         public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Difference2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Difference2.cs
@@ -134,6 +134,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -85,13 +85,11 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
-            $"{value.X.ToString(format, formatProvider)}, " +
-            $"{value.Y.ToString(format, formatProvider)}) u";
+        public string ToString(string? format, IFormatProvider? formatProvider)
+            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
-        public string ToString(string? format) => "(" +
-            $"{value.X.ToString(format)}, " +
-            $"{value.Y.ToString(format)}) u";
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -85,11 +85,13 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
+            $"{value.X.ToString(format, formatProvider)}, " +
+            $"{value.Y.ToString(format, formatProvider)}) u";
 
-        public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
+        public string ToString(string? format) => "(" +
+            $"{value.X.ToString(format)}, " +
+            $"{value.Y.ToString(format)}) u";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -88,6 +88,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Position2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Position2.cs
@@ -89,7 +89,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u";
 
         public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -131,13 +131,11 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
-            $"{value.X.ToString(format, formatProvider)}, " +
-            $"{value.Y.ToString(format, formatProvider)}) u/t";
+        public string ToString(string? format, IFormatProvider? formatProvider)
+            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t";
 
-        public string ToString(string? format) => "(" +
-            $"{value.X.ToString(format)}, " +
-            $"{value.Y.ToString(format)}) u/t";
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -134,6 +134,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t";
 
+        public string ToString(string? format)
+            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -131,11 +131,13 @@ namespace Bearded.Utilities.SpaceTime
 
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
-        public string ToString(string? format, IFormatProvider? formatProvider)
-            => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t";
+        public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
+            $"{value.X.ToString(format, formatProvider)}, " +
+            $"{value.Y.ToString(format, formatProvider)}) u/t";
 
-        public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t";
+        public string ToString(string? format) => "(" +
+            $"{value.X.ToString(format)}, " +
+            $"{value.Y.ToString(format)}) u/t";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
+++ b/Bearded.Utilities/SpaceTime/2d/Velocity2.cs
@@ -135,7 +135,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"({value.X.ToString(format, formatProvider)}, {value.Y.ToString(format, formatProvider)}) u/t";
 
         public string ToString(string? format)
-            => $"({value.X.ToString(format)}, {value.Y.ToString(format)}) u/t";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
@@ -128,10 +128,8 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u/t²";
 
-        public string ToString(string? format) => "(" +
-               $"{value.X.ToString(format)}, " +
-               $"{value.Y.ToString(format)}, " +
-               $"{value.Z.ToString(format)}) u/t²";
+        public string ToString(string? format)
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Acceleration3.cs
@@ -128,6 +128,11 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u/t²";
 
+        public string ToString(string? format) => "(" +
+               $"{value.X.ToString(format)}, " +
+               $"{value.Y.ToString(format)}, " +
+               $"{value.Z.ToString(format)}) u/t²";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/3d/Difference3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Difference3.cs
@@ -121,9 +121,14 @@ namespace Bearded.Utilities.SpaceTime
         public override string ToString() => ToString(null, CultureInfo.CurrentCulture);
 
         public string ToString(string? format, IFormatProvider? formatProvider) => "(" +
-            $"{value.X.ToString(format, formatProvider)}, " +
-            $"{value.Y.ToString(format, formatProvider)}, " +
-            $"{value.Z.ToString(format, formatProvider)}) u";
+               $"{value.X.ToString(format, formatProvider)}, " +
+               $"{value.Y.ToString(format, formatProvider)}, " +
+               $"{value.Z.ToString(format, formatProvider)}) u";
+
+        public string ToString(string? format) => "(" +
+               $"{value.X.ToString(format)}, " +
+               $"{value.Y.ToString(format)}, " +
+               $"{value.Z.ToString(format)}) u";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/3d/Difference3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Difference3.cs
@@ -125,10 +125,8 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u";
 
-        public string ToString(string? format) => "(" +
-               $"{value.X.ToString(format)}, " +
-               $"{value.Y.ToString(format)}, " +
-               $"{value.Z.ToString(format)}) u";
+        public string ToString(string? format)
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/3d/Position3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Position3.cs
@@ -99,6 +99,11 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u";
 
+        public string ToString(string? format) => "(" +
+               $"{value.X.ToString(format)}, " +
+               $"{value.Y.ToString(format)}, " +
+               $"{value.Z.ToString(format)}) u";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/3d/Position3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Position3.cs
@@ -99,10 +99,8 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u";
 
-        public string ToString(string? format) => "(" +
-               $"{value.X.ToString(format)}, " +
-               $"{value.Y.ToString(format)}, " +
-               $"{value.Z.ToString(format)}) u";
+        public string ToString(string? format)
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
@@ -125,10 +125,8 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u/t";
 
-        public string ToString(string? format) => "(" +
-               $"{value.X.ToString(format)}, " +
-               $"{value.Y.ToString(format)}, " +
-               $"{value.Z.ToString(format)}) u/t";
+        public string ToString(string? format)
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
+++ b/Bearded.Utilities/SpaceTime/3d/Velocity3.cs
@@ -125,6 +125,11 @@ namespace Bearded.Utilities.SpaceTime
                $"{value.Y.ToString(format, formatProvider)}, " +
                $"{value.Z.ToString(format, formatProvider)}) u/t";
 
+        public string ToString(string? format) => "(" +
+               $"{value.X.ToString(format)}, " +
+               $"{value.Y.ToString(format)}, " +
+               $"{value.Z.ToString(format)}) u/t";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -86,6 +86,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"|{value.ToString(format, formatProvider)}|";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)}|";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -87,7 +87,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"|{value.ToString(format, formatProvider)}|";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)}|";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -87,7 +87,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"|{value.ToString(format, formatProvider)}|";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)}|";
+            => $"|{value.ToString(format)}|";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/Squared.cs
+++ b/Bearded.Utilities/SpaceTime/Squared.cs
@@ -87,7 +87,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"|{value.ToString(format, formatProvider)}|";
 
         public string ToString(string? format)
-            => $"|{value.ToString(format)}|";
+            => $"{value.ToString(format)}|";
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
@@ -76,7 +76,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t²";
 
         public string ToString(string? format)
-            => $"{MoreMath.RadiansToDegrees(value).ToString(format)} °/t²";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularAcceleration.cs
@@ -75,6 +75,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t²";
 
+        public string ToString(string? format)
+            => $"{MoreMath.RadiansToDegrees(value).ToString(format)} °/t²";
+
         #endregion
 
         #region compare

--- a/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
@@ -75,6 +75,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t";
 
+        public string ToString(string? format)
+            => $"{MoreMath.RadiansToDegrees(value).ToString(format)} °/t";
+
         #endregion
 
         #region compare

--- a/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
+++ b/Bearded.Utilities/SpaceTime/angular/AngularVelocity.cs
@@ -76,7 +76,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{MoreMath.RadiansToDegrees(value).ToString(format, formatProvider)} °/t";
 
         public string ToString(string? format)
-            => $"{MoreMath.RadiansToDegrees(value).ToString(format)} °/t";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/gravity/Mass.cs
+++ b/Bearded.Utilities/SpaceTime/gravity/Mass.cs
@@ -43,7 +43,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} m";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} m";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/gravity/Mass.cs
+++ b/Bearded.Utilities/SpaceTime/gravity/Mass.cs
@@ -42,6 +42,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} m";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} m";
+
         #endregion
 
         #region compare

--- a/Bearded.Utilities/SpaceTime/time/Frequency.cs
+++ b/Bearded.Utilities/SpaceTime/time/Frequency.cs
@@ -50,6 +50,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} 1/t";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} 1/t";
+
         #endregion
 
         #region compare

--- a/Bearded.Utilities/SpaceTime/time/Frequency.cs
+++ b/Bearded.Utilities/SpaceTime/time/Frequency.cs
@@ -51,7 +51,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} 1/t";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} 1/t";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/time/Instant.cs
+++ b/Bearded.Utilities/SpaceTime/time/Instant.cs
@@ -60,7 +60,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} t";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} t";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/time/Instant.cs
+++ b/Bearded.Utilities/SpaceTime/time/Instant.cs
@@ -59,6 +59,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} t";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} t";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
+++ b/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
@@ -51,7 +51,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} t";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} t";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
+++ b/Bearded.Utilities/SpaceTime/time/TimeSpan.cs
@@ -50,6 +50,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} t";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} t";
+
         #endregion
 
         #region compare

--- a/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
@@ -65,6 +65,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} u/t²";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} u/t²";
+
         #endregion
 
         #region compare

--- a/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Acceleration.cs
@@ -66,7 +66,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} u/t²";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} u/t²";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/undirected/Speed.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Speed.cs
@@ -71,6 +71,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} u/t";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} u/t";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/undirected/Speed.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Speed.cs
@@ -72,7 +72,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} u/t";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} u/t";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 

--- a/Bearded.Utilities/SpaceTime/undirected/Unit.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Unit.cs
@@ -71,6 +71,9 @@ namespace Bearded.Utilities.SpaceTime
         public string ToString(string? format, IFormatProvider? formatProvider)
             => $"{value.ToString(format, formatProvider)} u";
 
+        public string ToString(string? format)
+            => $"{value.ToString(format)} u";
+
         #endregion
 
         #endregion

--- a/Bearded.Utilities/SpaceTime/undirected/Unit.cs
+++ b/Bearded.Utilities/SpaceTime/undirected/Unit.cs
@@ -72,7 +72,7 @@ namespace Bearded.Utilities.SpaceTime
             => $"{value.ToString(format, formatProvider)} u";
 
         public string ToString(string? format)
-            => $"{value.ToString(format)} u";
+            => ToString(format, CultureInfo.CurrentCulture);
 
         #endregion
 


### PR DESCRIPTION
<!-- This template is a guideline; use your own judgement to write a description that is easy to read and will help get the PR reviewed quickly and accurately -->

<!-- Please add a short, clear title that states what this PR changes -->

## ✨ What's this?
This adds another overload for ToString methods, that takes nullable format as its only parameter. I've also normalized the implementations to follow similar formatting.
<!-- Describe clearly and concisely what this PR changes -->

### 🔗 Relationships
<!-- Mention any issues or PRs that are connected to this -->

Closes #196

