### PR TITLE
🥈 Allow enumeration of priority queues

### DIFF
--- a/Bearded.Utilities/Collections/StaticPriorityQueue.cs
+++ b/Bearded.Utilities/Collections/StaticPriorityQueue.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 
@@ -9,7 +10,9 @@ namespace Bearded.Utilities.Collections
     /// </summary>
     /// <typeparam name="TPriority"></typeparam>
     /// <typeparam name="TValue"></typeparam>
-    public class StaticPriorityQueue<TPriority, TValue> where TPriority : IComparable<TPriority>
+    public class StaticPriorityQueue<TPriority, TValue>
+        : IEnumerable<KeyValuePair<TPriority, TValue>>
+        where TPriority : IComparable<TPriority>
     {
         /// <summary>
         /// Array-representation of the entire heap.
@@ -203,5 +206,15 @@ namespace Bearded.Utilities.Collections
             return 2 * i + 2;
         }
         #endregion
+
+        public IEnumerator<KeyValuePair<TPriority, TValue>> GetEnumerator()
+        {
+            for (var i = 0; i < Count; i++)
+            {
+                yield return data[i];
+            }
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
     }
 }


### PR DESCRIPTION

## ✨ What's this?
What the title says. I made PriorityQueue implement IEnumerable.

### 🔗 Relationships

N/A - I needed this to better debug TD's pathfinding.

## 🔍 Why do we want this?
Debugging is the main use case I can think of, but I'm sure there are other ways this might be useful? I do find myself enumerating regular queues from time to time...

## 🏗 How is it done?
The most straightforward way possible

### 💥 Breaking changes
None.

### 🔬 Why not another way?
No reason to overcomplicate, unless...

### 🦋 Side effects
If the priority queue is changed during enumeration, the behaviour is pretty much undefined (we could skip or duplicate entries, or maybe even return `default` or array overflow(?)). Solutions are to keep a 'version' int around and crash (before? after? the 'yield return' - or maybe we need a separate enumerator type) or to use a List instead of an array to store the entries and refer to List.GetEnumerator

## 💡 Review hints
The code is trivial. Consider the side effect above to see if we should perhaps refactor to use List or keep track of our own version int (I'd probably prefer List, because we're really just duplicating its functionality here).
