### PR TITLE
⭕ Implement circular arcs

### DIFF
--- a/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
+++ b/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
@@ -1,0 +1,98 @@
+using Bearded.Utilities.Geometry;
+using FluentAssertions;
+using FluentAssertions.Equivalency;
+using OpenTK.Mathematics;
+using Xunit;
+
+namespace Bearded.Utilities.Tests.Geometry
+{
+    public sealed class CircularArc2Tests
+    {
+        public sealed class Opposite
+        {
+            [Fact]
+            public void ReturnsMinorArcIfArcIsMajor()
+            {
+                var arc = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, -270.Degrees());
+
+                var actual = arc.Opposite;
+
+                var expected = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, 90.Degrees());
+                actual.Should().BeEquivalentTo(expected, circularArc2Equivalency);
+            }
+
+            [Fact]
+            public void ReturnsMajorArcIfArcIsMinor()
+            {
+                var arc = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, 90.Degrees());
+
+                var actual = arc.Opposite;
+
+                var expected = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, -270.Degrees());
+                actual.Should().BeEquivalentTo(expected, circularArc2Equivalency);
+            }
+        }
+
+        public sealed class Reversed
+        {
+            [Fact]
+            public void ReturnsReversedArc()
+            {
+                var arc = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, 90.Degrees());
+
+                var actual = arc.Reversed;
+
+                var expected =
+                    CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.FromDegrees(90), -90.Degrees());
+                actual.Should().BeEquivalentTo(expected, circularArc2Equivalency);
+            }
+        }
+
+        public sealed class ShortestArcBetweenDirections
+        {
+            [Fact]
+            public void ReturnsMinorArc()
+            {
+                var actual = CircularArc2.ShortestArcBetweenDirections(
+                    Vector2.Zero,
+                    1,
+                    Direction2.FromDegrees(0),
+                    Direction2.FromDegrees(90));
+
+                var expected = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, 90.Degrees());
+                actual.Should().BeEquivalentTo(expected, circularArc2Equivalency);
+            }
+        }
+
+        public sealed class LongestArcBetweenDirections
+        {
+            [Fact]
+            public void ReturnsMajorArc()
+            {
+                var actual = CircularArc2.LongestArcBetweenDirections(
+                    Vector2.Zero,
+                    1,
+                    Direction2.FromDegrees(0),
+                    Direction2.FromDegrees(90));
+
+                var expected = CircularArc2.FromStartAndAngle(Vector2.Zero, 1, Direction2.Zero, -270.Degrees());
+                actual.Should().BeEquivalentTo(expected, circularArc2Equivalency);
+            }
+        }
+
+        private static EquivalencyAssertionOptions<CircularArc2> circularArc2Equivalency(
+            EquivalencyAssertionOptions<CircularArc2> options)
+        {
+            // Override the comparing of circular arcs to compare by member, so that we can get approximate comparisons
+            // for the angle.
+            return options
+                .ComparingByMembers<CircularArc2>()
+                .Including(a => a.Center)
+                .Including(a => a.Radius)
+                .Including(a => a.Start)
+                .Including(a => a.Angle)
+                .Using<Angle>(ctx => ctx.Subject.Radians.Should().BeApproximately(ctx.Expectation.Radians, 0.01f))
+                .WhenTypeIs<Angle>();
+        }
+    }
+}

--- a/Bearded.Utilities/Geometry/CircularArc2.cs
+++ b/Bearded.Utilities/Geometry/CircularArc2.cs
@@ -1,0 +1,89 @@
+using System;
+using OpenTK.Mathematics;
+
+namespace Bearded.Utilities.Geometry
+{
+    /// <summary>
+    /// Represents an arc of a circle between a pair of distinct points.
+    /// </summary>
+    public readonly struct CircularArc2 : IEquatable<CircularArc2>
+    {
+        public Vector2 Center { get; }
+        public float Radius { get; }
+        public Direction2 Start { get; }
+        public Angle Angle { get; }
+
+        public Direction2 End => Start + Angle;
+        public Vector2 StartPoint => Center + Radius * Start.Vector;
+        public Vector2 EndPoint => Center + Radius * End.Vector;
+
+        public float ArcLength => Angle.Radians * Radius;
+
+        /// <summary>
+        /// Returns the major arc if this arc is the minor arc, and returns the major arc if this is the minor arc.
+        /// </summary>
+        public CircularArc2 Opposite =>
+            new CircularArc2(Center, Radius, Start, Angle.Sign() * -(MathConstants.TwoPi.Radians() - Angle.Abs()));
+
+        /// <summary>
+        /// Returns the same arc with the start and end directions swapped.
+        /// </summary>
+        public CircularArc2 Reversed => new CircularArc2(Center, Radius, End, -Angle);
+
+        /// <summary>
+        /// Constructs the minor arc in the circle with specified center and radius between the given directions.
+        /// </summary>
+        public static CircularArc2 ShortestArcBetweenDirections(
+            Vector2 center, float radius, Direction2 start, Direction2 end)
+        {
+            return new CircularArc2(center, radius, start, end - start);
+        }
+
+        /// <summary>
+        /// Constructs the major arc in the circle with specified center and radius between the given directions.
+        /// </summary>
+        public static CircularArc2 LongestArcBetweenDirections(
+            Vector2 center, float radius, Direction2 start, Direction2 end)
+        {
+            var shortestAngle = end - start;
+            var longestAngle = -(MathConstants.TwoPi.Radians() - shortestAngle);
+
+            return new CircularArc2(center, radius, start, longestAngle);
+        }
+
+        /// <summary>
+        /// Constructs the arc in the circle with specified center and radius starting in the given direction,
+        /// subtending the given angle.
+        /// </summary>
+        public static CircularArc2 FromStartAndAngle(
+            Vector2 center, float radius, Direction2 start, Angle angle)
+        {
+            return new CircularArc2(center, radius, start, angle);
+        }
+
+        private CircularArc2(Vector2 center, float radius, Direction2 start, Angle angle)
+        {
+            Center = center;
+            Radius = radius;
+            Start = start;
+            Angle = angle;
+        }
+
+        public bool Equals(CircularArc2 other) =>
+            Center.Equals(other.Center)
+            && Radius.Equals(other.Radius)
+            && Start.Equals(other.Start)
+            && Angle.Equals(other.Angle);
+
+        public override bool Equals(object? obj) => obj is CircularArc2 other && Equals(other);
+
+        public override int GetHashCode() => HashCode.Combine(Center, Radius, Start, Angle);
+
+        public static bool operator ==(CircularArc2 left, CircularArc2 right) => left.Equals(right);
+        public static bool operator !=(CircularArc2 left, CircularArc2 right) => !left.Equals(right);
+
+        public override string ToString() =>
+            string.Join(System.Environment.NewLine,
+                $"Center = {Center}", $"Radius = {Radius}", $"Start = {Start}", $"Angle = {Angle}");
+    }
+}


### PR DESCRIPTION
## ✨ What's this?
This PR adds a new geometry type for circular arcs in 2D space.

## 🔍 Why do we want this?
Circular arcs are a pretty useful geometric shape, so having a way to represent them first of all is quite helpful. Additionally, I plan to send follow-up PRs that allow simple geometric constructions such as constructing a circular arc given two lines and a radius (to automatically create rounded corners).

## 🏗 How is it done?
The `CircularArc2` is a new readonly struct keeping track of a `center`, `radius`, `start` and `angle`. It provides several properties to easily construct similar arcs, and there are several factory functions to create arcs in different ways.

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
There are some other representations that I considered. The most obvious alternative is to keep start and end, instead of start and angle. However, two points on a circle define both the major and minor arc, so we would have to keep track of a separate bit. Using the angle to store that bit makes sense. Other representations are less convenient to calculate back from (e.g. circle center and two points), since most interesting properties of an arc follow almost trivially from the stored attributes, while restoring these attributes from those properties is generally non-trivial.

### 🦋 Side effects
Future PRs will provide further functions to construct these arcs when the attributes aren't known yet.

## 💡 Review hints
The added tests were purposefully not meant to provide 100% coverage, but should at least cover all the interesting construction logic.
