### PR TITLE
✅ Rewrite circular arc tests to untie from members

### DIFF
--- a/Bearded.Utilities.Tests/Generators/DirectionGenerators.cs
+++ b/Bearded.Utilities.Tests/Generators/DirectionGenerators.cs
@@ -5,7 +5,7 @@ namespace Bearded.Utilities.Tests.Generators
 {
     static class DirectionGenerators
     {
-        public static class All
+        public sealed class All
         {
             public static Arbitrary<Direction2> Directions() =>
                 Arb.Generate<uint>().Select(i => Direction2.FromDegrees(i * 360f / (1L << 32))).ToArbitrary();

--- a/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
+++ b/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
@@ -19,7 +19,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingShortArcBetweenIdenticalDirections_ReturnsZeroLengthArc(Direction2 fromTo)
+        public void ShortArcBetweenIdenticalDirectionsIsZeroLength(Direction2 fromTo)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
 
@@ -27,7 +27,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingShortArcBetweenOppositeDirections_ReturnsNegativeDirectionArc(Direction2 from)
+        public void ShortArcBetweenOppositeDirectionsHasMinusPiAngle(Direction2 from)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, -from);
 
@@ -35,7 +35,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingShortArc_ReturnsArcWithAngleSmallerThanPiRad(Direction2 from, Direction2 to)
+        public void ShortArcHasAngleWithMagnitudeSmallerThanPi(Direction2 from, Direction2 to)
         {
             if (from == to) return;
 
@@ -45,7 +45,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingLongArcBetweenIdenticalDirections_ReturnsFullLengthArc(Direction2 fromTo)
+        public void LongArcBetweenIdenticalDirectionsIsFullCircle(Direction2 fromTo)
         {
             var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
 
@@ -53,7 +53,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingLongArcBetweenOppositeDirections_ReturnsPositiveDirectionArc(Direction2 from)
+        public void LongArcBetweenOppositeDirectionsHasPiAngle(Direction2 from)
         {
             var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, -from);
 
@@ -61,7 +61,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingLongArc_ReturnsArcWithAngleLargerThanPiRad(Direction2 from, Direction2 to)
+        public void LongArcHasAngleWithMagnitudeLargerThanPi(Direction2 from, Direction2 to)
         {
             if (from == to) return;
 
@@ -71,7 +71,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleSmallerThanMinusTwoPi_Throws(Direction2 from)
+        public void ArcWithAngleSmallerThanMinusTwoPiIsInvalid(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(-7));
@@ -80,7 +80,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleEqualsMinusTwoPi_DoesNotThrow(Direction2 from)
+        public void ArcWithAngleMinusTwoPiIsValid(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(-MathConstants.TwoPi));
@@ -89,7 +89,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleSmallerThanMinusPi_ReturnsALongArc(Direction2 from)
+        public void ArcWithAngleLessThanMinusPiIsLongArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(-4));
@@ -98,7 +98,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleEqualsMinusPi_ReturnsAShortArc(Direction2 from)
+        public void ArcWithAngleMinusPiIsShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(-MathConstants.Pi));
@@ -107,7 +107,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleLargerThanMinusPi_ReturnsAShortArc(Direction2 from)
+        public void ArcWithAngleMoreThanMinusPiIsShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(-2));
@@ -116,7 +116,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithZeroAngle_ReturnsAShortArc(Direction2 from)
+        public void ArcWithAngleZeroIsShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.Zero);
@@ -125,7 +125,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleSmallerThanPi_ReturnsAShortArc(Direction2 from)
+        public void ArcWithAngleLessThanPiIsShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(2));
@@ -134,7 +134,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleEqualsPi_ReturnsALongArc(Direction2 from)
+        public void ArcWithAnglePiIsLongArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(MathConstants.Pi));
@@ -143,7 +143,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleLargerThanPi_ReturnsALongArc(Direction2 from)
+        public void ArcWithAngleMoreThanPiIsLongArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(4));
@@ -152,7 +152,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleEqualsTwoPi_Throws(Direction2 from)
+        public void ArcWithAngleTwoPiIsInvalid(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(MathConstants.TwoPi));
@@ -161,7 +161,7 @@ namespace Bearded.Utilities.Tests.Geometry
         }
 
         [Property]
-        public void CreatingArcWithAngleLargerThanTwoPi_Throws(Direction2 from)
+        public void ArcWithAngleMoreThanPiIsInvalid(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
                 Vector2.Zero, 1, from, Angle.FromRadians(7));

--- a/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
+++ b/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
@@ -3,6 +3,7 @@ using Bearded.Utilities.Geometry;
 using Bearded.Utilities.Tests.Assertions;
 using Bearded.Utilities.Tests.Generators;
 using FluentAssertions;
+using FsCheck;
 using FsCheck.Xunit;
 using OpenTK.Mathematics;
 
@@ -12,7 +13,12 @@ namespace Bearded.Utilities.Tests.Geometry
     {
         private const float epsilon = 0.001f;
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public CircularArc2Tests()
+        {
+            Arb.Register<DirectionGenerators.All>();
+        }
+
+        [Property]
         public void CreatingShortArcBetweenIdenticalDirections_ReturnsZeroLengthArc(Direction2 fromTo)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
@@ -20,7 +26,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.Angle.Radians.Should().BeApproximately(0, epsilon);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingShortArcBetweenOppositeDirections_ReturnsNegativeDirectionArc(Direction2 from)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, -from);
@@ -28,7 +34,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.Angle.Radians.Should().BeApproximately(-MathConstants.Pi, epsilon);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingShortArc_ReturnsArcWithAngleSmallerThanPiRad(Direction2 from, Direction2 to)
         {
             if (from == to) return;
@@ -38,7 +44,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.Angle.MagnitudeInRadians.Should().BeInRange(0, MathConstants.Pi);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingLongArcBetweenIdenticalDirections_ReturnsFullLengthArc(Direction2 fromTo)
         {
             var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
@@ -46,7 +52,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.Angle.Radians.Should().BeApproximately(MathConstants.TwoPi, epsilon);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingLongArcBetweenOppositeDirections_ReturnsPositiveDirectionArc(Direction2 from)
         {
             var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, -from);
@@ -54,7 +60,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.Angle.Radians.Should().BeApproximately(MathConstants.Pi, epsilon);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingLongArc_ReturnsArcWithAngleLargerThanPiRad(Direction2 from, Direction2 to)
         {
             if (from == to) return;
@@ -64,7 +70,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.Angle.MagnitudeInRadians.Should().BeInRange(MathConstants.Pi, MathConstants.TwoPi);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleSmallerThanMinusTwoPi_Throws(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
@@ -73,7 +79,7 @@ namespace Bearded.Utilities.Tests.Geometry
             action.Should().Throw<ArgumentException>();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleEqualsMinusTwoPi_DoesNotThrow(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
@@ -82,7 +88,7 @@ namespace Bearded.Utilities.Tests.Geometry
             action.Should().NotThrow();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleSmallerThanMinusPi_ReturnsALongArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -91,7 +97,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsLongArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleEqualsMinusPi_ReturnsAShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -100,7 +106,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsShortArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleLargerThanMinusPi_ReturnsAShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -109,7 +115,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsShortArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithZeroAngle_ReturnsAShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -118,7 +124,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsShortArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleSmallerThanPi_ReturnsAShortArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -127,7 +133,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsShortArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleEqualsPi_ReturnsALongArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -136,7 +142,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsLongArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleLargerThanPi_ReturnsALongArc(Direction2 from)
         {
             var arc = CircularArc2.FromStartAndAngle(
@@ -145,7 +151,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.IsLongArc.Should().BeTrue();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleEqualsTwoPi_Throws(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
@@ -154,7 +160,7 @@ namespace Bearded.Utilities.Tests.Geometry
             action.Should().Throw<ArgumentException>();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void CreatingArcWithAngleLargerThanTwoPi_Throws(Direction2 from)
         {
             Action action = () => CircularArc2.FromStartAndAngle(
@@ -163,7 +169,7 @@ namespace Bearded.Utilities.Tests.Geometry
             action.Should().Throw<ArgumentException>();
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void OppositeOfALongArcIsAShortArc(Direction2 from, Direction2 to)
         {
             if (from == to) return;
@@ -176,7 +182,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(expected);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void OppositeOfAShortArcIsALongArc(Direction2 from, Direction2 to)
         {
             if (from == to) return;
@@ -189,7 +195,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(expected);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void OppositeOfAZeroLengthArcIsAFullLengthArc(Direction2 fromTo)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
@@ -200,7 +206,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(expected);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void OppositeOfAFullLengthArcIsAZeroLengthArc(Direction2 fromTo)
         {
             var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
@@ -211,7 +217,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(expected);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void ReverseOfAShortArcIsTheShortArcWithDirectionsSwitched(Direction2 from, Direction2 to)
         {
             if (from == to) return;
@@ -224,7 +230,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(expected);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void ReverseOfALongArcIsTheLongArcWithDirectionsSwitched(Direction2 from, Direction2 to)
         {
             if (from == to) return;
@@ -237,7 +243,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(expected);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void ReverseOfAZeroLengthArcIsTheOriginalArc(Direction2 fromTo)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
@@ -247,7 +253,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(arc);
         }
 
-        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        [Property]
         public void ReverseOfAFullCircleArcIsTheOriginalArc(Direction2 fromTo)
         {
             var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
@@ -257,8 +263,7 @@ namespace Bearded.Utilities.Tests.Geometry
             actual.Should().Be(arc);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void StartPointIsPointOnArc(Direction2 from, Direction2 to, float radius)
         {
             if (from == to) return;
@@ -268,8 +273,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.StartPoint.LengthSquared.Should().BeApproximately(radius * radius, epsilon);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void ArcStartingAtDirectionZeroHasStartPointOnXAxis(Direction2 to, float radius)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, Direction2.Zero, to);
@@ -277,8 +281,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.StartPoint.Should().BeApproximately(radius * Vector2.UnitX, epsilon);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void ArcStartingAtDirection90DegHasStartPointOnYAxis(Direction2 to, float radius)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, Direction2.FromDegrees(90), to);
@@ -286,8 +289,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.StartPoint.Should().BeApproximately(radius * Vector2.UnitY, epsilon);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void ArcStartingAtDirection135HasStartPointInThirdQuadrant(Direction2 to, float radius)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(
@@ -297,8 +299,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.StartPoint.Y.Should().BeNegative();
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void EndPointIsPointOnArc(Direction2 from, Direction2 to, float radius)
         {
             if (from == to) return;
@@ -308,8 +309,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.EndPoint.LengthSquared.Should().BeApproximately(radius * radius, epsilon);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void ArcEndingAtDirectionZeroHasEndPointOnXAxis(Direction2 from, float radius)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, Direction2.Zero);
@@ -317,8 +317,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.EndPoint.Should().BeApproximately(radius * Vector2.UnitX, epsilon);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void ArcEndingAtDirection90DegHasEndPointOnYAxis(Direction2 from, float radius)
         {
             var arc =
@@ -327,8 +326,7 @@ namespace Bearded.Utilities.Tests.Geometry
             arc.EndPoint.Should().BeApproximately(radius * Vector2.UnitY, epsilon);
         }
 
-        [Property(Arbitrary = new[]
-            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        [Property(Arbitrary = new[] { typeof(FloatGenerators.PositiveCircleRadius) })]
         public void ArcEndingAtDirection135DegHasEndPointInThirdQuadrant(Direction2 from, float radius)
         {
             var arc = CircularArc2.ShortArcBetweenDirections(

--- a/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
+++ b/Bearded.Utilities.Tests/Geometry/CircularArc2Tests.cs
@@ -10,354 +10,332 @@ namespace Bearded.Utilities.Tests.Geometry
 {
     public sealed class CircularArc2Tests
     {
-        public sealed class ShortArcBetweenDirections
+        private const float epsilon = 0.001f;
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingShortArcBetweenIdenticalDirections_ReturnsZeroLengthArc(Direction2 fromTo)
         {
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsZeroLengthArcIfDirectionsAreEqual(Direction2 fromTo)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
 
-                arc.Angle.Radians.Should().BeApproximately(0, 0.01f);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsNegativeDirectionArcIfDirectionsAreOpposite(Direction2 from)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, -from);
-
-                arc.Angle.Radians.Should().BeApproximately(-MathConstants.Pi, 0.01f);
-            }
+            arc.Angle.Radians.Should().BeApproximately(0, epsilon);
         }
 
-        public sealed class LongArcBetweenDirections
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingShortArcBetweenOppositeDirections_ReturnsNegativeDirectionArc(Direction2 from)
         {
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsFullLengthArcInPositiveDirectionIfDirectionsAreEqual(Direction2 fromTo)
-            {
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, -from);
 
-                arc.Angle.Radians.Should().BeApproximately(MathConstants.TwoPi, 0.01f);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsPositiveDirectionArcIfDirectionsAreOpposite(Direction2 from)
-            {
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, -from);
-
-                arc.Angle.Radians.Should().BeApproximately(MathConstants.Pi, 0.01f);
-            }
+            arc.Angle.Radians.Should().BeApproximately(-MathConstants.Pi, epsilon);
         }
 
-        public sealed class FromStartAndAngle
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingShortArc_ReturnsArcWithAngleSmallerThanPiRad(Direction2 from, Direction2 to)
         {
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ThrowsIfAngleIsSmallerThanMinusTwoPi(Direction2 from)
-            {
-                Action action = () => CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(-7));
+            if (from == to) return;
 
-                action.Should().Throw<ArgumentException>();
-            }
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
 
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void DoesNotThrowIfAngleIsMinusTwoPi(Direction2 from)
-            {
-                Action action = () => CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(-MathConstants.TwoPi));
-
-                action.Should().NotThrow();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsLongArcIfAngleSmallerThanMinusPi(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(-4));
-
-                arc.IsLongArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsShortArcIfAngleEqualsMinusPi(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(-MathConstants.Pi));
-
-                arc.IsShortArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsShortArcIfAngleIsLargerThanMinusPi(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(-2));
-
-                arc.IsShortArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsShortArcIfAngleIsZero(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.Zero);
-
-                arc.IsShortArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsShortArcIfAngleIsSmallerThanPi(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(2));
-
-                arc.IsShortArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsLongArcIfAngleEqualsPi(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(MathConstants.Pi));
-
-                arc.IsLongArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsLongArcIfAngleIsLargerThanPi(Direction2 from)
-            {
-                var arc = CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(4));
-
-                arc.IsLongArc.Should().BeTrue();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ThrowsIfAngleIsTwoPi(Direction2 from)
-            {
-                Action action = () => CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(MathConstants.TwoPi));
-
-                action.Should().Throw<ArgumentException>();
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void DoesNotThrowIfAngleIsLargerThanTwoPi(Direction2 from)
-            {
-                Action action = () => CircularArc2.FromStartAndAngle(
-                    Vector2.Zero, 1, from, Bearded.Utilities.Geometry.Angle.FromRadians(7));
-
-                action.Should().Throw<ArgumentException>();
-            }
+            arc.Angle.MagnitudeInRadians.Should().BeInRange(0, MathConstants.Pi);
         }
 
-        public sealed class Opposite
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingLongArcBetweenIdenticalDirections_ReturnsFullLengthArc(Direction2 fromTo)
         {
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsShortArcIfArcIsLong(Direction2 from, Direction2 to)
-            {
-                if (from == to) return;
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
 
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
-
-                var actual = arc.Opposite;
-
-                var expected = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
-                actual.Should().Be(expected);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsLongArcIfArcIsShort(Direction2 from, Direction2 to)
-            {
-                if (from == to) return;
-
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
-
-                var actual = arc.Opposite;
-
-                var expected = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
-                actual.Should().Be(expected);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsFullCircleInPositiveDirectionIfArcIsZeroLength(Direction2 fromTo)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
-
-                var actual = arc.Opposite;
-
-                var expected = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
-                actual.Should().Be(expected);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsZeroLengthArcIfArcIsFullCircle(Direction2 fromTo)
-            {
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
-
-                var actual = arc.Opposite;
-
-                var expected = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
-                actual.Should().Be(expected);
-            }
+            arc.Angle.Radians.Should().BeApproximately(MathConstants.TwoPi, epsilon);
         }
 
-        public sealed class Reversed
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingLongArcBetweenOppositeDirections_ReturnsPositiveDirectionArc(Direction2 from)
         {
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsReversedShortArcIfArcIsShort(Direction2 from, Direction2 to)
-            {
-                if (from == to) return;
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, -from);
 
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
-
-                var actual = arc.Reversed;
-
-                var expected = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, to, from);
-                actual.Should().Be(expected);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void ReturnsReversedShortArcIfArcIsLong(Direction2 from, Direction2 to)
-            {
-                if (from == to) return;
-
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
-
-                var actual = arc.Reversed;
-
-                var expected = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, to, from);
-                actual.Should().Be(expected);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void IsANoOpWhenArcIsZeroLength(Direction2 fromTo)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
-
-                var actual = arc.Reversed;
-
-                actual.Should().Be(arc);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void IsANoOpWhenArcIsFullCircle(Direction2 fromTo)
-            {
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
-
-                var actual = arc.Reversed;
-
-                actual.Should().Be(arc);
-            }
+            arc.Angle.Radians.Should().BeApproximately(MathConstants.Pi, epsilon);
         }
 
-        public sealed class Angle
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingLongArc_ReturnsArcWithAngleLargerThanPiRad(Direction2 from, Direction2 to)
         {
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void IsSmallerThanPiRadForShortArcs(Direction2 from, Direction2 to)
-            {
-                if (from == to) return;
+            if (from == to) return;
 
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
 
-                arc.Angle.MagnitudeInRadians.Should().BeInRange(0, MathConstants.Pi);
-            }
-
-            [Property(Arbitrary = new[] {typeof(DirectionGenerators.All)})]
-            public void IsLargerThanPiRadForShortArcs(Direction2 from, Direction2 to)
-            {
-                if (from == to) return;
-
-                var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
-
-                arc.Angle.MagnitudeInRadians.Should().BeInRange(MathConstants.Pi, MathConstants.TwoPi);
-            }
+            arc.Angle.MagnitudeInRadians.Should().BeInRange(MathConstants.Pi, MathConstants.TwoPi);
         }
 
-        public sealed class StartPoint
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleSmallerThanMinusTwoPi_Throws(Direction2 from)
         {
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsPointOnArc(Direction2 from, Direction2 to, float radius)
-            {
-                if (from == to) return;
+            Action action = () => CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(-7));
 
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, to);
-
-                arc.StartPoint.LengthSquared.Should().BeApproximately(radius * radius, 0.01f);
-            }
-
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsCorrectPointOnXAxis(Direction2 to, float radius)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, Direction2.Zero, to);
-
-                arc.StartPoint.Should().BeApproximately(radius * Vector2.UnitX, 0.01f);
-            }
-
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsCorrectPointOnYAxis(Direction2 to, float radius)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, Direction2.FromDegrees(90), to);
-
-                arc.StartPoint.Should().BeApproximately(radius * Vector2.UnitY, 0.01f);
-            }
-
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsPointInCorrectQuadrant(Direction2 to, float radius)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(
-                    Vector2.Zero, radius, Direction2.FromDegrees(-135), to);
-
-                arc.StartPoint.X.Should().BeNegative();
-                arc.StartPoint.Y.Should().BeNegative();
-            }
+            action.Should().Throw<ArgumentException>();
         }
 
-        public sealed class EndPoint
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleEqualsMinusTwoPi_DoesNotThrow(Direction2 from)
         {
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsPointOnArc(Direction2 from, Direction2 to, float radius)
-            {
-                if (from == to) return;
+            Action action = () => CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(-MathConstants.TwoPi));
 
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, to);
+            action.Should().NotThrow();
+        }
 
-                arc.EndPoint.LengthSquared.Should().BeApproximately(radius * radius, 0.01f);
-            }
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleSmallerThanMinusPi_ReturnsALongArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(-4));
 
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsCorrectPointOnXAxis(Direction2 from, float radius)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, Direction2.Zero);
+            arc.IsLongArc.Should().BeTrue();
+        }
 
-                arc.EndPoint.Should().BeApproximately(radius * Vector2.UnitX, 0.01f);
-            }
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleEqualsMinusPi_ReturnsAShortArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(-MathConstants.Pi));
 
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsCorrectPointOnYAxis(Direction2 from, float radius)
-            {
-                var arc =
-                    CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, Direction2.FromDegrees(90));
+            arc.IsShortArc.Should().BeTrue();
+        }
 
-                arc.EndPoint.Should().BeApproximately(radius * Vector2.UnitY, 0.01f);
-            }
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleLargerThanMinusPi_ReturnsAShortArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(-2));
 
-            [Property(Arbitrary = new[]
-                {typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius)})]
-            public void ReturnsPointInCorrectQuadrant(Direction2 from, float radius)
-            {
-                var arc = CircularArc2.ShortArcBetweenDirections(
-                    Vector2.Zero, radius, from, Direction2.FromDegrees(-135));
+            arc.IsShortArc.Should().BeTrue();
+        }
 
-                arc.EndPoint.X.Should().BeNegative();
-                arc.EndPoint.Y.Should().BeNegative();
-            }
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithZeroAngle_ReturnsAShortArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.Zero);
+
+            arc.IsShortArc.Should().BeTrue();
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleSmallerThanPi_ReturnsAShortArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(2));
+
+            arc.IsShortArc.Should().BeTrue();
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleEqualsPi_ReturnsALongArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(MathConstants.Pi));
+
+            arc.IsLongArc.Should().BeTrue();
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleLargerThanPi_ReturnsALongArc(Direction2 from)
+        {
+            var arc = CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(4));
+
+            arc.IsLongArc.Should().BeTrue();
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleEqualsTwoPi_Throws(Direction2 from)
+        {
+            Action action = () => CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(MathConstants.TwoPi));
+
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void CreatingArcWithAngleLargerThanTwoPi_Throws(Direction2 from)
+        {
+            Action action = () => CircularArc2.FromStartAndAngle(
+                Vector2.Zero, 1, from, Angle.FromRadians(7));
+
+            action.Should().Throw<ArgumentException>();
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void OppositeOfALongArcIsAShortArc(Direction2 from, Direction2 to)
+        {
+            if (from == to) return;
+
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
+
+            var actual = arc.Opposite;
+
+            var expected = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
+            actual.Should().Be(expected);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void OppositeOfAShortArcIsALongArc(Direction2 from, Direction2 to)
+        {
+            if (from == to) return;
+
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
+
+            var actual = arc.Opposite;
+
+            var expected = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
+            actual.Should().Be(expected);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void OppositeOfAZeroLengthArcIsAFullLengthArc(Direction2 fromTo)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+
+            var actual = arc.Opposite;
+
+            var expected = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+            actual.Should().Be(expected);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void OppositeOfAFullLengthArcIsAZeroLengthArc(Direction2 fromTo)
+        {
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+
+            var actual = arc.Opposite;
+
+            var expected = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+            actual.Should().Be(expected);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void ReverseOfAShortArcIsTheShortArcWithDirectionsSwitched(Direction2 from, Direction2 to)
+        {
+            if (from == to) return;
+
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, from, to);
+
+            var actual = arc.Reversed;
+
+            var expected = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, to, from);
+            actual.Should().Be(expected);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void ReverseOfALongArcIsTheLongArcWithDirectionsSwitched(Direction2 from, Direction2 to)
+        {
+            if (from == to) return;
+
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, from, to);
+
+            var actual = arc.Reversed;
+
+            var expected = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, to, from);
+            actual.Should().Be(expected);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void ReverseOfAZeroLengthArcIsTheOriginalArc(Direction2 fromTo)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+
+            var actual = arc.Reversed;
+
+            actual.Should().Be(arc);
+        }
+
+        [Property(Arbitrary = new[] { typeof(DirectionGenerators.All) })]
+        public void ReverseOfAFullCircleArcIsTheOriginalArc(Direction2 fromTo)
+        {
+            var arc = CircularArc2.LongArcBetweenDirections(Vector2.Zero, 1, fromTo, fromTo);
+
+            var actual = arc.Reversed;
+
+            actual.Should().Be(arc);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void StartPointIsPointOnArc(Direction2 from, Direction2 to, float radius)
+        {
+            if (from == to) return;
+
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, to);
+
+            arc.StartPoint.LengthSquared.Should().BeApproximately(radius * radius, epsilon);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void ArcStartingAtDirectionZeroHasStartPointOnXAxis(Direction2 to, float radius)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, Direction2.Zero, to);
+
+            arc.StartPoint.Should().BeApproximately(radius * Vector2.UnitX, epsilon);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void ArcStartingAtDirection90DegHasStartPointOnYAxis(Direction2 to, float radius)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, Direction2.FromDegrees(90), to);
+
+            arc.StartPoint.Should().BeApproximately(radius * Vector2.UnitY, epsilon);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void ArcStartingAtDirection135HasStartPointInThirdQuadrant(Direction2 to, float radius)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(
+                Vector2.Zero, radius, Direction2.FromDegrees(-135), to);
+
+            arc.StartPoint.X.Should().BeNegative();
+            arc.StartPoint.Y.Should().BeNegative();
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void EndPointIsPointOnArc(Direction2 from, Direction2 to, float radius)
+        {
+            if (from == to) return;
+
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, to);
+
+            arc.EndPoint.LengthSquared.Should().BeApproximately(radius * radius, epsilon);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void ArcEndingAtDirectionZeroHasEndPointOnXAxis(Direction2 from, float radius)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, Direction2.Zero);
+
+            arc.EndPoint.Should().BeApproximately(radius * Vector2.UnitX, epsilon);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void ArcEndingAtDirection90DegHasEndPointOnYAxis(Direction2 from, float radius)
+        {
+            var arc =
+                CircularArc2.ShortArcBetweenDirections(Vector2.Zero, radius, from, Direction2.FromDegrees(90));
+
+            arc.EndPoint.Should().BeApproximately(radius * Vector2.UnitY, epsilon);
+        }
+
+        [Property(Arbitrary = new[]
+            { typeof(DirectionGenerators.All), typeof(FloatGenerators.PositiveCircleRadius) })]
+        public void ArcEndingAtDirection135DegHasEndPointInThirdQuadrant(Direction2 from, float radius)
+        {
+            var arc = CircularArc2.ShortArcBetweenDirections(
+                Vector2.Zero, radius, from, Direction2.FromDegrees(-135));
+
+            arc.EndPoint.X.Should().BeNegative();
+            arc.EndPoint.Y.Should().BeNegative();
         }
     }
 }


### PR DESCRIPTION
## ✨ What's this?
This PR rewrites the circular arc tests to no longer be grouped by the member they test.

### 🔗 Relationships
N/A

## 🔍 Why do we want this?
We want to focus on behaviours, rather than members in our tests.

The reason we are rewriting an existing test is to have a single canonical example that we can refer contributors to the bearded libraries to as part of our effort to improve test coverage.

## 🏗 How is it done?
This PR attempts to maintain the current test coverage, but rebrand its tests to talk more about the cause and effect, rather than the members it affects. This was largely possible without changing the tests, though some reordering took place to make things make more sense together.

There are sort of two naming schemes in use now:

1. `Cause_Effect`
2. `Fact`

The first is used mostly for the factory methods (e.g. `CreatingShortArc_ReturnsArcWithAngleSmallerThanPiRad`). This is specifically talking about how the arc created in a specific way has certain properties.

The latter is used to describe the properties of the arc (e.g. `OppositeOfAShortArcIsALongArc`), and is primarily used to describe how the different public members of the arc should behave.

I do not know if we should keep these two side by side, whether one is preferred over the other, or whether we don't care at all as long as the name is clear.

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
N/A

### 🦋 Side effects
Once this PR is approved, I will create overarching issues for each bearded library, with the hacktoberfest tag and pinned to the top, referring to these tests as an example of what we'd like to see in further test PRs.

## 💡 Review hints
I am not entirely convinced with the names, they seem really long which harms readability. My recommendation would be to focus on the names, but if you think the tests should be organised/grouped differently, then I keep myself open to feedback.
