### PR TITLE
🟪 Implement bivectors

### DIFF
--- a/Bearded.Utilities.Testing/Geometry/Bivector2Assertions.cs
+++ b/Bearded.Utilities.Testing/Geometry/Bivector2Assertions.cs
@@ -1,0 +1,42 @@
+using Bearded.Utilities.Geometry;
+using FluentAssertions;
+
+namespace Bearded.Utilities.Testing.Geometry
+{
+    public sealed class Bivector2Assertions
+    {
+        private readonly Bivector2 subject;
+
+        public Bivector2Assertions(Bivector2 instance) => subject = instance;
+
+        [CustomAssertion]
+        public AndConstraint<Bivector2Assertions> Be(Bivector2 other, string because = "", params object[] becauseArgs)
+        {
+            AssertionExtensions.Should(subject).Be(other, because, becauseArgs);
+            return new AndConstraint<Bivector2Assertions>(this);
+        }
+
+        [CustomAssertion]
+        public AndConstraint<Bivector2Assertions> NotBe(Bivector2 other, string because = "", params object[] becauseArgs)
+        {
+            AssertionExtensions.Should(subject).NotBe(other, because, becauseArgs);
+            return new AndConstraint<Bivector2Assertions>(this);
+        }
+
+        [CustomAssertion]
+        public AndConstraint<Bivector2Assertions> BeApproximately(
+            Bivector2 other, float precision, string because = "", params object[] becauseArgs)
+        {
+            subject.Magnitude.Should().BeApproximately(other.Magnitude, precision, because, becauseArgs);
+            return new AndConstraint<Bivector2Assertions>(this);
+        }
+
+        [CustomAssertion]
+        public AndConstraint<Bivector2Assertions> NotBeApproximately(
+            Bivector2 other, float precision, string because = "", params object[] becauseArgs)
+        {
+            subject.Magnitude.Should().NotBeApproximately(other.Magnitude, precision, because, becauseArgs);
+            return new AndConstraint<Bivector2Assertions>(this);
+        }
+    }
+}

--- a/Bearded.Utilities.Testing/Geometry/Bivector2Extensions.cs
+++ b/Bearded.Utilities.Testing/Geometry/Bivector2Extensions.cs
@@ -1,0 +1,9 @@
+using Bearded.Utilities.Geometry;
+
+namespace Bearded.Utilities.Testing.Geometry
+{
+    public static class Bivector2Extensions
+    {
+        public static Bivector2Assertions Should(this Bivector2 instance) => new Bivector2Assertions(instance);
+    }
+}

--- a/Bearded.Utilities.Tests/Generators/FloatGenerators.cs
+++ b/Bearded.Utilities.Tests/Generators/FloatGenerators.cs
@@ -31,5 +31,16 @@ namespace Bearded.Utilities.Tests.Generators
                     .Select(i => ((float) i + 1) / 1000)
                     .ToArbitrary();
         }
+
+        /// <summary>
+        /// Generates floats with reasonable maximum magnitude to avoid positive infinities when doing arithmetic.
+        /// </summary>
+        public sealed class ForArithmetic
+        {
+            public static Arbitrary<float> Floats()
+                => Arb.Default.Int32().Generator
+                    .Select(i => 0.001f * i)
+                    .ToArbitrary();
+        }
     }
 }

--- a/Bearded.Utilities.Tests/Generators/Vector2Generators.cs
+++ b/Bearded.Utilities.Tests/Generators/Vector2Generators.cs
@@ -1,0 +1,15 @@
+using FsCheck;
+using OpenTK.Mathematics;
+
+namespace Bearded.Utilities.Tests.Generators
+{
+    sealed class Vector2Generators
+    {
+        public sealed class All
+        {
+            public static Arbitrary<Vector2> Vectors() =>
+                Arb.From(FloatGenerators.ForArithmetic.Floats().Generator.Two()
+                    .Select(tuple => new Vector2(tuple.Item1, tuple.Item2)));
+        }
+    }
+}

--- a/Bearded.Utilities.Tests/Geometry/Bivector2Tests.cs
+++ b/Bearded.Utilities.Tests/Geometry/Bivector2Tests.cs
@@ -1,0 +1,120 @@
+using System;
+using Bearded.Utilities.Geometry;
+using Bearded.Utilities.Testing.Geometry;
+using Bearded.Utilities.Tests.Generators;
+using FluentAssertions;
+using FsCheck;
+using FsCheck.Xunit;
+using OpenTK.Mathematics;
+using Xunit;
+
+namespace Bearded.Utilities.Tests.Geometry
+{
+    public sealed class Bivector2Tests
+    {
+        private const float epsilon = 1E-6f;
+
+        public Bivector2Tests()
+        {
+            Arb.Register<FloatGenerators.ForArithmetic>();
+            Arb.Register<Vector2Generators.All>();
+        }
+
+        [Fact]
+        public void OuterProductOfUnitVectorsIsOne()
+        {
+            var outerProduct = Bivector2.OuterProduct(Vector2.UnitX, Vector2.UnitY);
+
+            outerProduct.Should().BeApproximately(Bivector2.One, epsilon);
+        }
+
+        [Property]
+        public void OuterProductOfVectorWithSelfIsZero(Vector2 vector)
+        {
+            var outerProduct = Bivector2.OuterProduct(vector, vector);
+
+            outerProduct.Should().BeApproximately(Bivector2.Zero, epsilon);
+        }
+
+        [Property]
+        public void OuterProductOfCollinearVectorsIsZero(Vector2 vector, float scalar)
+        {
+            var outerProduct = Bivector2.OuterProduct(vector, vector * scalar);
+
+            outerProduct.Should().BeApproximately(Bivector2.Zero, epsilon);
+        }
+
+        [Property]
+        public void OuterProductOfNonCollinearVectorsIsNonZero(Vector2 left, Vector2 right)
+        {
+            if (areCollinear(left, right)) return;
+
+            var outerProduct = Bivector2.OuterProduct(left, right);
+
+            outerProduct.Should().NotBe(Bivector2.Zero);
+        }
+
+        [Property]
+        public void OuterProductIsAntiSymmetric(Vector2 left, Vector2 right)
+        {
+            var outerProduct1 = Bivector2.OuterProduct(left, right);
+            var outerProduct2 = Bivector2.OuterProduct(right, left);
+
+            outerProduct1.Should().Be(-outerProduct2);
+        }
+
+        [Property]
+        public void AddingBivectorsAddsMagnitudes(float f1, float f2)
+        {
+            var bivector1 = new Bivector2(f1);
+            var bivector2 = new Bivector2(f2);
+            var sum = bivector1 + bivector2;
+
+            sum.Should().BeApproximately(new Bivector2(f1 + f2), epsilon);
+        }
+
+        [Property]
+        public void SubtractingBivectorsSubtractsMagnitudes(float f1, float f2)
+        {
+            var bivector1 = new Bivector2(f1);
+            var bivector2 = new Bivector2(f2);
+            var difference = bivector1 - bivector2;
+
+            difference.Should().BeApproximately(new Bivector2(f1 - f2), epsilon);
+        }
+
+        [Property]
+        public void BivectorsWithSameMagnitudeAreEqual(float magnitude)
+        {
+            var bivector1 = new Bivector2(magnitude);
+            var bivector2 = new Bivector2(magnitude);
+
+            bivector1.Equals(bivector2).Should().BeTrue();
+            (bivector1 == bivector2).Should().BeTrue();
+            (bivector1 != bivector2).Should().BeFalse();
+            bivector1.GetHashCode().Should().Be(bivector2.GetHashCode());
+        }
+
+        [Property]
+        public void BivectorsWithDifferentMagnitudeAreNotEqual(float f1, float f2)
+        {
+            // ReSharper disable once CompareOfFloatsByEqualityOperator
+            if (f1 == f2) f2++;
+
+            var bivector1 = new Bivector2(f1);
+            var bivector2 = new Bivector2(f2);
+
+            bivector1.Equals(bivector2).Should().BeFalse();
+            (bivector1 == bivector2).Should().BeFalse();
+            (bivector1 != bivector2).Should().BeTrue();
+        }
+
+        private static bool areCollinear(Vector2 v1, Vector2 v2)
+        {
+            if (v1.Y == 0 && v2.Y == 0) return true;
+            if (v1 == Vector2.Zero || v2 == Vector2.Zero) return true;
+            if (v1.Y == 0 || v2.Y == 0) return false;
+            return Math.Abs(v1.X / v1.Y - v2.X / v2.Y) < epsilon;
+        }
+    }
+}

--- a/Bearded.Utilities/Geometry/Bivector2.cs
+++ b/Bearded.Utilities/Geometry/Bivector2.cs
@@ -1,0 +1,43 @@
+using System;
+using OpenTK.Mathematics;
+
+namespace Bearded.Utilities.Geometry
+{
+    /// <summary>
+    /// Represents a bivector in two-dimensional Euclidean space.
+    /// </summary>
+    public readonly struct Bivector2 : IEquatable<Bivector2>
+    {
+        public float Magnitude { get; }
+
+        public static readonly Bivector2 Zero = new Bivector2(0);
+
+        public static readonly Bivector2 One = new Bivector2(1);
+
+        public static Bivector2 OuterProduct(Vector2 left, Vector2 right) =>
+            new Bivector2(left.X * right.Y - left.Y * right.X);
+
+        public Bivector2(float magnitude)
+        {
+            Magnitude = magnitude;
+        }
+
+        public static Bivector2 operator +(Bivector2 left, Bivector2 right) =>
+            new Bivector2(left.Magnitude + right.Magnitude);
+
+        public static Bivector2 operator -(Bivector2 left, Bivector2 right) =>
+            new Bivector2(left.Magnitude - right.Magnitude);
+
+        public static Bivector2 operator -(Bivector2 bivector) => new Bivector2(-bivector.Magnitude);
+
+        public bool Equals(Bivector2 other) => Magnitude.Equals(other.Magnitude);
+
+        public override bool Equals(object? obj) => obj is Bivector2 other && Equals(other);
+
+        public override int GetHashCode() => Magnitude.GetHashCode();
+
+        public static bool operator ==(Bivector2 left, Bivector2 right) => left.Equals(right);
+
+        public static bool operator !=(Bivector2 left, Bivector2 right) => !left.Equals(right);
+    }
+}


### PR DESCRIPTION
## ✨ What's this?
This PR implements representations for bivectors in 2 and 3 dimensions.

### 🔗 Relationships
Required for #229 

## 🔍 Why do we want this?
Bivectors are a geometric construct needed to implement rotors. They are also a basic concept in geometric algebra in general.

## 🏗 How is it done?
The PR adds two new structs: `Bivector2` and `Bivector3` representing bivectors in 2 and 3 dimensions respectively. Note that copies with double precision could be made in case we want to do so.

The additions are accompanied by the necessary tests, including additions to the testing library to make it possible to test these easily. Coverage shows that all the code is 100% covered.

### 💥 Breaking changes
N/A

### 🔬 Why not another way?
Having a type safe way of representing bivectors falls within the general trend in these libraries to be type safe where we can.

The types have been added to the `Geometry` namespace, though I am not convinced that is the right place to put them. I believe that a `Math` or `Mathematics` namespace would be more appropriate. Bivectors have clear geometric uses, but like vectors, can be considered a pure mathematical construct. Remaining consistent with OpenTK, which puts the vector and matrix types in a `Mathematics` namespace, sounds desirable. The reason I avoided adding this namespace is my worry that having a `Math` namespace would cause confusion as to why our math helpers would not be in said namespace, but in `Core`. Making a breaking change is something I wanted to avoid.

Furthermore, some attention needs to be given to the name `OuterProduct`. Outer product isn't the mathematically correct name. "Exterior product" and "wedge product" are more mathematically pure. However, in the context of talking about geometric algebra and rotors, the term "outer product" is used, and so Googling for this concept may yield better results. I can be convinced to rename though. My preference would be `Bivectorn.Wedge` in that case.

### 🦋 Side effects
Further code changes will be needed to use these bivectors in rotors.

## 💡 Review hints
Please comment on the open questions in "why not another way?" section above.

Further reading to understand the subject matter:

* 📚 [Let's remove quaternions from every engine](https://marctenbosch.com/quaternions/)
* 💻 [Reference implementation by Marc ten Bosch](https://marctenbosch.com/quaternions/code.htm)
* 📚 [Bivector Wikipedia article](https://en.wikipedia.org/wiki/Bivector)
* 🎥 [A Swift Introduction to Geometric Algebra](https://www.youtube.com/watch?v=60z_hpEAtD8)
