### PR TITLE
🐛 Fix benchmarks by not overwriting bad data

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -52,7 +52,7 @@ jobs:
         uses: actions/cache@v2
         with:
           path: ./benchmarks
-          key: ${{ runner.os }}-benchmark
+          key: ${{ runner.os }}-benchmark-v2
       - name: Process benchmark result
         uses: Happypig375/github-action-benchmark@v1.8.2
         with:


### PR DESCRIPTION
## ✨ What's this?
Fixes benchmarks.

## 🔍 Why do we want this?
Benchmarks are broken right now.

## 🏗 How is it done?
I misunderstood the way that benchmark data should be passed through the cache, I believe. Instead of passing our own JSON file to the cache, the benchmark action will actually overwrite its own custom JSON in the `externalDataJsonPath`, meaning that the copy I did afterwards wrote invalid JSON to the cache, causing any subsequent benchmark runs to fail.

This PR removes that custom copy, and lets the action restore its own JSON, which should fix subsequent benchmark runs.

## 💡 Review hints
N/A