### PR TITLE
🆙 Add support for .net6 and C#10

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
+      - name: Setup .NET Core 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -36,10 +40,10 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-      - name: Setup .NET Core 5.0
+      - name: Setup .NET Core 6.0
         uses: actions/setup-dotnet@v1
         with:
-          dotnet-version: 5.0.x
+          dotnet-version: 6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -22,6 +22,10 @@ jobs:
         uses: actions/setup-dotnet@v1
         with:
           dotnet-version: 5.0.x
+      - name: Setup .NET Core 6.0
+        uses: actions/setup-dotnet@v1
+        with:
+          dotnet-version: 6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build

--- a/Bearded.Utilities.Benchmarks/Bearded.Utilities.Benchmarks.csproj
+++ b/Bearded.Utilities.Benchmarks/Bearded.Utilities.Benchmarks.csproj
@@ -2,8 +2,8 @@
 
     <PropertyGroup>
         <OutputType>Exe</OutputType>
-        <TargetFramework>net5.0</TargetFramework>
-        <LangVersion>8</LangVersion>
+        <TargetFramework>net6.0</TargetFramework>
+        <LangVersion>10</LangVersion>
         <Nullable>enable</Nullable>
     </PropertyGroup>
 

--- a/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
+++ b/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.8.3" />

--- a/Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
+++ b/Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
+++ b/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="5.6.0" />

--- a/Bearded.Utilities.Tests/Collections/PriorityQueueTests.cs
+++ b/Bearded.Utilities.Tests/Collections/PriorityQueueTests.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Linq;
-using Bearded.Utilities.Collections;
 using Bearded.Utilities.Linq;
 using FluentAssertions;
 using FsCheck.Xunit;
@@ -9,6 +8,8 @@ using Xunit;
 
 namespace Bearded.Utilities.Tests.Collections
 {
+    using Bearded.Utilities.Collections;
+
     public class PriorityQueueTests
     {
         [Fact]

--- a/Bearded.Utilities/Algorithms/CoffmanGraham.cs
+++ b/Bearded.Utilities/Algorithms/CoffmanGraham.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using System.Collections.Immutable;
 using System.Linq;
 using Bearded.Utilities.Graphs;
-using Bearded.Utilities.Linq;
 
 namespace Bearded.Utilities.Algorithms
 {
+    using Linq;
     /// <summary>
     /// This class contains logic to take a partially ordered set of elements and split it in a sequence of layers such
     /// that the following holds:

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -1,9 +1,9 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <LangVersion>8</LangVersion>
+    <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
-    <TargetFrameworks>net5.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="OpenTK.Mathematics" Version="4.4.0" />


### PR DESCRIPTION

## ✨ What's this?
.Net6 is out, let's support it!

## 🏗 How is it done?
- target .net6 on top of 5 and 3.1 with all projects (except benchmarks which we only run on the latest framework)
- a couple of using statement changes to unambiguafy references that overlap with things added in .net6
- set lang-version to 10 in all projects (this doesn't break anything)

### 💥 Breaking changes
None at all I believe. We still target 5 and 3.1 as before. They are officially supported until May/December next year, so we can keep them around for now as well.
