### PR TITLE
🙈 Hide namespace commit from git blame

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,2 @@
+# Moving from namespace blocks to file scope namespaces with C#10
+98d88a68b4f9f8daee09a255501fa764670e6319


### PR DESCRIPTION

### 🔗 Relationships
Hides the almost 100% file rewrite from #251

## 🔍 Why do we want this?
Because blaming people is fun?
