### PR TITLE
🆙 Add dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,24 @@
+# See the documentation for all configuration options:
+# https://help.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "nuget"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆"
+    assignees:
+      - "tomrijnbeek"
+
+  - package-ecosystem: "github-actions"
+    # Workflow files stored in the
+    # default location of `.github/workflows`
+    directory: "/"
+    schedule:
+      interval: "daily"
+    commit-message:
+      prefix: "⬆"
+    assignees:
+      - "tomrijnbeek"


### PR DESCRIPTION
## ✨ What's this?
Supports dependabot config.

## 🔍 Why do we want this?
Automatically updates dependencies, keeping the library up-to-date. This is especially useful in light of other bearded libraries using this, to make sure they keep consistent versions of common dependencies like OpenTK.

## 🏗 How is it done?
This config is copied verbatim from beardgame/audio repository.

## 💡 Review hints
Feel free to squash and merge.
