### PR TITLE
🐛 Explicitly provide packages to publish

### DIFF
--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -42,9 +42,9 @@ jobs:
       # Create the NuGet package
       # Note that we substr the release version to get the numbers only, without
       # the 'v' prefix.
-      - name: Pack binary
+      - name: Pack Bearded.Utilities
         run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Utilities/Bearded.Utilities.csproj
-      - name: Pack binary
+      - name: Pack Bearded.Utilities.Testing
         run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
 
       # Create a GitHub release

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -43,7 +43,9 @@ jobs:
       # Note that we substr the release version to get the numbers only, without
       # the 'v' prefix.
       - name: Pack binary
-        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1}
+        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Utilities/Bearded.Utilities.csproj
+      - name: Pack binary
+        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
 
       # Create a GitHub release
       - name: Create a Release


### PR DESCRIPTION
## ✨ What's this?
Changes the automatic discovery of packages into a list of commands per package.

## 🔍 Why do we want this?
Right now it will also automatically release the benchmarks project. In general, we probably want to be in control of what we push to NuGet.

## 🏗 How is it done?
beardgame/graphics#46 solved a similar issue for the graphics library. This follows that same approach.

## 💡 Review hints
This can't be tested until we next release a new version.
