### PR TITLE
⬆ Manually upgrade OpenTK in one batch

### DIFF
--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -13,7 +13,4 @@
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">
-    <PackageReference Include="OpenTK.Windowing.Common" Version="4.0.0" />
-  </ItemGroup>
 </Project>

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -10,6 +10,7 @@
     <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.1" />
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.1" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
+    <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.1'">

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -6,9 +6,9 @@
     <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK.Mathematics" Version="4.4.0" />
-    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.4.0" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.4.0" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.7.1" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.7.1" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.7.1" />
     <PackageReference Include="System.Collections.Immutable" Version="5.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>


### PR DESCRIPTION
## ✨ What's this?
This PR updates all the OpenTK dependencies in one go.

It also removes some unnecessary code that was there for .NET standard 2.1 only, which is no longer supported.

### 🔗 Relationships
Replaces #256 and #262 

## 🔍 Why do we want this?
Dependabot only does single dependencies at a time. The OpenTK dependencies break if you use different versions for the different dependencies.

## 🏗 How is it done?
Manually updating the csproj, since even the NuGet UI doesn't like the one-by-one updating of packages.

### 💥 Breaking changes
Projects implicitly depending on the OpenTK version we provide will be broken.

### 🔬 Why not another way?
We could switch to the full OpenTK package which also pulls in OpenAL and other libraries, so we only ever have a single dependency to deal with.

### 🦋 Side effects
We had to also add an explicit dependency to `System.Runtime.CompilerServices.Unsafe`, because both `OpenTK` and `System.Collections.Immutable` depend on them, but different versions. The current setup generates a warning, but tests run fine.

## 💡 Review hints
N/A
