### PR TITLE
🏆 Improve release pipeline and generate release notes

### DIFF
--- a/.github/release.yml
+++ b/.github/release.yml
@@ -1,0 +1,23 @@
+changelog:
+  exclude:
+    labels:
+      - dependencies
+      - ignore-for-release
+    authors:
+      - dependabot
+      - octocat
+  categories:
+    - title: 💥 Breaking changes
+      labels:
+        - breaking-change
+    - title: ✨ New features
+      labels:
+        - enhancement
+        - feature
+    - title: 🐛 Bugfixes
+      labels:
+        - bug
+        - fix
+    - title: 📝 Other changes
+      labels:
+        - "*"

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -14,18 +14,13 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET Core 5.0
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET Core 6.0
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build
@@ -40,7 +35,7 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
-      - name: Setup .NET Core 6.0
+      - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -44,15 +44,15 @@ jobs:
 
       # Create a GitHub release
       - name: Create a Release
-        id: create_release
-        uses: actions/create-release@v1
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        uses: softprops/action-gh-release@v1
         with:
           tag_name: ${{ env.RELEASE_VERSION }}
-          release_name: Release ${{ env.RELEASE_VERSION }}
+          name: Release ${{ env.RELEASE_VERSION }}
           draft: false
           prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
+          generate_release_notes: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          files: "**/*.nupkg"
 
       # Push the NuGet package to the package providers
       - name: Push release to NuGet

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -14,18 +14,13 @@ jobs:
     steps:
       # Build library and run tests
       - uses: actions/checkout@v3
-      - name: Setup .NET Core 3.1
+      - name: Setup .NET
         uses: actions/setup-dotnet@v2
         with:
-          dotnet-version: 3.1.x
-      - name: Setup .NET Core 5.0
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 5.0.x
-      - name: Setup .NET Core 6.0
-        uses: actions/setup-dotnet@v2
-        with:
-          dotnet-version: 6.0.x
+          dotnet-version: |
+            3.1.x
+            5.0.x
+            6.0.x
       - name: Install dependencies
         run: dotnet restore
       - name: Build


### PR DESCRIPTION
## ✨ What's this?
This PR makes some improvements to the GitHub actions, doing some cleanup and maintenance on them, as well as migrating it to an actually maintained GitHub action creating a release, which will automatically include PR titles as release notes.

### 🔗 Relationships
Closes #255 

## 🔍 Why do we want this?
* The existing GitHub action is deprecated; this moves us to an actually maintained GitHub action.
* Having release notes will include the release notes as snippet in dependabot PRs, as well as looking more official 🤓

## 🏗 How is it done?
Manual changes based on the documentation of the [new action](https://github.com/softprops/action-gh-release) as well as [GitHub documentation](https://docs.github.com/en/repositories/releasing-projects-on-github/automatically-generated-release-notes#configuring-automatically-generated-release-notes) to create the `release.yml` file which determines how release notes are generated by GitHub.

### 🔬 Why not another way?
Other actions to do the same exist, but this one is linked to by GitHub itself.

## 💡 Review hints
N/A