### PR TITLE
Transition to using explicit nullable types (#184)

### DIFF
--- a/Bearded.Utilities/Algorithms/CoffmanGraham.cs
+++ b/Bearded.Utilities/Algorithms/CoffmanGraham.cs
@@ -177,7 +177,7 @@ public static class CoffmanGraham
 
     public static ISolver SolverForReducedGraphs(int maxLayerSize) => new ReducedGraphSolver(maxLayerSize);
 
-    private struct DecreasingNumberSequence : IComparable<DecreasingNumberSequence>, IComparable
+    private readonly struct DecreasingNumberSequence : IComparable<DecreasingNumberSequence>, IComparable
     {
         private readonly ImmutableList<int> numbers;
 
@@ -186,7 +186,7 @@ public static class CoffmanGraham
             this.numbers = numbers;
         }
 
-        public int CompareTo(object obj) => CompareTo((DecreasingNumberSequence) obj);
+        public int CompareTo(object? obj) => CompareTo((DecreasingNumberSequence) (obj ?? throw new ArgumentNullException()));
 
         public int CompareTo(DecreasingNumberSequence other)
         {

--- a/Bearded.Utilities/Collections/DeletableObjectList.cs
+++ b/Bearded.Utilities/Collections/DeletableObjectList.cs
@@ -16,7 +16,7 @@ public sealed class DeletableObjectList<T> : IEnumerable<T>
 {
     #region Fields and Properties
 
-    private readonly List<T> list;
+    private readonly List<T?> list;
 
     private int enumerators;
     private int count;
@@ -47,7 +47,7 @@ public sealed class DeletableObjectList<T> : IEnumerable<T>
 
     public DeletableObjectList(int capacity)
     {
-        list = new List<T>(capacity);
+        list = new List<T?>(capacity);
         MaxEmptyFraction = 0.2f;
     }
 

--- a/Bearded.Utilities/Collections/DeletableObjectListEnumerator.cs
+++ b/Bearded.Utilities/Collections/DeletableObjectListEnumerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Bearded.Utilities.Collections;
@@ -10,13 +11,19 @@ internal class DeletableObjectListEnumerator<T> : IEnumerator<T>
     where T : class, IDeletable
 {
     private readonly DeletableObjectList<T> deletableObjectList;
-    private readonly List<T> list;
+    private readonly List<T?> list;
     private int i;
+    private T? current;
 
     object System.Collections.IEnumerator.Current => Current;
-    public T Current { get; private set; }
 
-    public DeletableObjectListEnumerator(DeletableObjectList<T> deletableObjectList, List<T> list)
+    public T Current
+    {
+        get => current ?? throw new InvalidOperationException();
+        private set => current = value;
+    }
+
+    public DeletableObjectListEnumerator(DeletableObjectList<T> deletableObjectList, List<T?> list)
     {
         this.deletableObjectList = deletableObjectList;
         this.list = list;

--- a/Bearded.Utilities/Collections/MutableLinkedList.cs
+++ b/Bearded.Utilities/Collections/MutableLinkedList.cs
@@ -13,12 +13,11 @@ public sealed class MutableLinkedList<T> : IEnumerable<T>
 {
     #region Fields and Properties
 
-    private readonly LinkedList<MutableLinkedListEnumerator<T>> enumerators =
-        new LinkedList<MutableLinkedListEnumerator<T>>();
+    private readonly LinkedList<MutableLinkedListEnumerator<T>> enumerators = new();
 
-    public MutableLinkedListNode<T> First { get; private set; }
+    public MutableLinkedListNode<T>? First { get; private set; }
 
-    public MutableLinkedListNode<T> Last { get; private set; }
+    public MutableLinkedListNode<T>? Last { get; private set; }
 
     public int Count { get; private set; }
 
@@ -56,7 +55,7 @@ public sealed class MutableLinkedList<T> : IEnumerable<T>
         else
         {
             node.Prev = Last;
-            Last.Next = node;
+            Last!.Next = node; // We know that Last is not null here, as the list is not empty.
         }
 
         Last = node;
@@ -147,7 +146,7 @@ public sealed class MutableLinkedList<T> : IEnumerable<T>
             throw new ArgumentException("Object must already be in list before inserting.");
         if (beforeThis.List != this)
             throw new ArgumentException("The object to insert before must be in the same list.");
-        if (node != Last)
+        if (node != Last || node.Prev == null)
             throw new ArgumentException("Inserted object must be last object in list.");
         if (node == beforeThis)
             throw new ArgumentException("Cannot insert object before itself.");
@@ -173,7 +172,7 @@ public sealed class MutableLinkedList<T> : IEnumerable<T>
     {
         var e = new MutableLinkedListEnumerator<T>(this);
         enumerators.AddFirst(e);
-        e.SetNode(enumerators.First);
+        e.SetNode(enumerators.First!); // We know First is not null as we just added e
         return e;
     }
 

--- a/Bearded.Utilities/Collections/MutableLinkedListEnumerator.cs
+++ b/Bearded.Utilities/Collections/MutableLinkedListEnumerator.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 
 namespace Bearded.Utilities.Collections;
@@ -21,19 +22,15 @@ internal sealed class MutableLinkedListEnumerator<T> : IEnumerator<T>
         this.list = list;
     }
 
-    private LinkedListNode<MutableLinkedListEnumerator<T>> node;
+    private LinkedListNode<MutableLinkedListEnumerator<T>>? node;
     public void SetNode(LinkedListNode<MutableLinkedListEnumerator<T>> node)
     {
-        if (this.node == null)
-            this.node = node;
+        this.node ??= node;
     }
 
-    public T Current
-    {
-        get { return current.Value; }
-    }
+    public T Current => current?.Value ?? throw new InvalidOperationException();
 
-    private MutableLinkedListNode<T> current;
+    private MutableLinkedListNode<T>? current;
 
     public void OnObjectRemove(MutableLinkedListNode<T> obj)
     {
@@ -48,6 +45,8 @@ internal sealed class MutableLinkedListEnumerator<T> : IEnumerator<T>
 
     public void Dispose()
     {
+        if (node is null) return;
+
         list.ForgetEnumerator(node);
     }
 
@@ -69,12 +68,14 @@ internal sealed class MutableLinkedListEnumerator<T> : IEnumerator<T>
                 currentWasDeleted = false;
                 return true;
             }
-            current = current.Next;
-            if (current == null)
+
+            if (current?.Next == null)
             {
                 done = true;
                 return false;
             }
+
+            current = current.Next;
         }
         return true;
     }
@@ -87,9 +88,5 @@ internal sealed class MutableLinkedListEnumerator<T> : IEnumerator<T>
         currentWasDeleted = false;
     }
 
-    object System.Collections.IEnumerator.Current
-    {
-        get { return Current; }
-    }
-
+    object System.Collections.IEnumerator.Current => Current;
 }

--- a/Bearded.Utilities/Collections/MutableLinkedListNode.cs
+++ b/Bearded.Utilities/Collections/MutableLinkedListNode.cs
@@ -1,4 +1,6 @@
 
+using System;
+
 namespace Bearded.Utilities.Collections;
 
 /// <summary>
@@ -25,23 +27,21 @@ public class MutableLinkedListNode<T>
 
     #region Fields and Properties
 
-    private readonly T value;
-
     /// <summary>
     /// The value stored in the node.
     /// </summary>
-    public T Value { get { return value; } }
+    public T? Value { get; }
 
     // Next, Prev and List are internally writeable to
     // simplify addition, removal and insertion code.
     // Do not mess with them!
-    internal MutableLinkedListNode<T> Next { get; set; }
-    internal MutableLinkedListNode<T> Prev { get; set; }
+    internal MutableLinkedListNode<T>? Next { get; set; }
+    internal MutableLinkedListNode<T>? Prev { get; set; }
 
     /// <summary>
     /// The list the node is part of.
     /// </summary>
-    public MutableLinkedList<T> List { get; internal set; }
+    public MutableLinkedList<T>? List { get; internal set; }
 
     internal bool ChangingList { get; private set; }
 
@@ -51,12 +51,12 @@ public class MutableLinkedListNode<T>
 
     internal MutableLinkedListNode(T value)
     {
-        this.value = value;
+        Value = value;
     }
 
     internal MutableLinkedListNode()
     {
-        value = this as T;
+        Value = this as T;
     }
 
     #endregion
@@ -89,7 +89,7 @@ public class MutableLinkedListNode<T>
     /// <param name="beforeThis">The node to add this before.</param>
     public void InsertBefore(MutableLinkedListNode<T> beforeThis)
     {
-        List.InsertBefore(this, beforeThis);
+        List?.InsertBefore(this, beforeThis);
     }
 
     /// <summary>
@@ -97,7 +97,7 @@ public class MutableLinkedListNode<T>
     /// </summary>
     public void RemoveFromList()
     {
-        List.Remove(this);
+        List?.Remove(this);
     }
 
     #endregion

--- a/Bearded.Utilities/Collections/PrefixTrie.cs
+++ b/Bearded.Utilities/Collections/PrefixTrie.cs
@@ -13,7 +13,7 @@ public sealed class PrefixTrie : ICollection<string>
     {
         private readonly Dictionary<char, Node>? values;
 
-        public string Key { get; }
+        public string? Key { get; }
 
         #region creating
 

--- a/Bearded.Utilities/Collections/PriorityQueue.cs
+++ b/Bearded.Utilities/Collections/PriorityQueue.cs
@@ -9,7 +9,9 @@ namespace Bearded.Utilities.Collections;
 /// </summary>
 /// <typeparam name="TPriority"></typeparam>
 /// <typeparam name="TValue"></typeparam>
-public sealed class PriorityQueue<TPriority, TValue> : StaticPriorityQueue<TPriority, TValue> where TPriority : IComparable<TPriority>
+public sealed class PriorityQueue<TPriority, TValue> : StaticPriorityQueue<TPriority, TValue>
+    where TPriority : IComparable<TPriority>
+    where TValue : notnull
 {
     private readonly Dictionary<TValue, int> valueDict = new Dictionary<TValue, int>();
 

--- a/Bearded.Utilities/Core/Environment.cs
+++ b/Bearded.Utilities/Core/Environment.cs
@@ -43,7 +43,7 @@ public static class Environment
     #endregion
 
     #region User settings directory
-    private static string userSettingsDirectory;
+    private static string? userSettingsDirectory;
 
     private static string buildUserSettingsDirectory()
     {
@@ -67,8 +67,7 @@ public static class Environment
                     return linuxConfigDir;
 
                 var linuxHomeDir = System.Environment.GetEnvironmentVariable("HOME");
-                // ReSharper disable once AssignNullToNotNullAttribute
-                return string.IsNullOrEmpty(linuxConfigDir) ? "." : Path.Combine(linuxHomeDir, ".config");
+                return string.IsNullOrEmpty(linuxConfigDir) ? "." : Path.Combine(linuxHomeDir!, ".config");
             default:
                 throw new InvalidOperationException("Encountered unknown platform.");
         }
@@ -80,7 +79,7 @@ public static class Environment
     /// For OSX: ~/Library/Application Support
     /// For Linux: ~/.config
     /// </summary>
-    public static string UserSettingsDirectory => userSettingsDirectory ?? (userSettingsDirectory = buildUserSettingsDirectory());
+    public static string UserSettingsDirectory => userSettingsDirectory ??= buildUserSettingsDirectory();
 
     /// <summary>
     /// Gets the default user setting directory for a given game name.

--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -5,88 +5,131 @@ using Bearded.Utilities.Monads;
 
 namespace Bearded.Utilities;
 
-public readonly struct Maybe<T> : IEquatable<Maybe<T>>
+public abstract class Maybe<T> : IEquatable<Maybe<T>>
     where T : notnull
 {
-    private bool hasValue => value is not null;
-    private readonly T? value;
 
-    private Maybe(T value)
-    {
-        this.value = value;
-    }
+    public static Maybe<T> Nothing => new Nothing<T>();
 
-    public static Maybe<T> Nothing => default;
+    internal static Maybe<T> Just(T value) => new Just<T>(value);
 
-    internal static Maybe<T> Just(T value) => new(value);
+    public abstract T ValueOrDefault(T @default);
 
-    public T ValueOrDefault(T @default) => hasValue ? value! : @default;
+    public abstract T ValueOrDefault(Func<T> defaultProvider);
 
-    public T ValueOrDefault(Func<T> defaultProvider) => hasValue ? value! : defaultProvider();
+    public abstract Result<T, TError> ValueOrFailure<TError>(TError error);
 
-    public Result<T, TError> ValueOrFailure<TError>(TError error) =>
-        hasValue ? (Result<T, TError>) Result.Success(value!) : Result.Failure(error);
+    public abstract Result<T, TError> ValueOrFailure<TError>(Func<TError> errorProvider);
 
-    public Result<T, TError> ValueOrFailure<TError>(Func<TError> errorProvider) =>
-        hasValue ? (Result<T, TError>) Result.Success(value!) : Result.Failure(errorProvider());
+    public abstract Maybe<TOut> Select<TOut>(Func<T, TOut> selector) where TOut : notnull;
 
-    public Maybe<TOut> Select<TOut>(Func<T, TOut> selector) where TOut : notnull =>
-        hasValue ? Maybe.Just(selector(value!)) : Maybe<TOut>.Nothing;
+    public abstract Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector) where TOut : notnull;
 
-    public Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector) where TOut : notnull  =>
-        hasValue ? selector(value!) : Maybe<TOut>.Nothing;
+    public abstract Maybe<T> Where(Func<T, bool> predicate);
 
-    public Maybe<T> Where(Func<T, bool> predicate) => hasValue && predicate(value!) ? this : Nothing;
+    public abstract void Match(Action<T> onValue);
 
-    public void Match(Action<T> onValue)
-    {
-        if (hasValue)
-            onValue(value!);
-    }
+    public abstract void Match(Action<T> onValue, Action onNothing);
 
-    public void Match(Action<T> onValue, Action onNothing)
-    {
-        if (hasValue)
-        {
-            onValue(value!);
-        }
-        else
-        {
-            onNothing();
-        }
-    }
+    public abstract TResult Match<TResult>(Func<T, TResult> onValue, Func<TResult> onNothing);
 
-    public TResult Match<TResult>(Func<T, TResult> onValue, Func<TResult> onNothing)
-    {
-        return hasValue ? onValue(value!) : onNothing();
-    }
-
-    public bool Equals(Maybe<T> other) =>
-        hasValue == other.hasValue && EqualityComparer<T>.Default.Equals(value, other.value);
-
-    public override bool Equals(object? obj) => obj is Maybe<T> other && Equals(other);
-
-    public override int GetHashCode() => hasValue ? EqualityComparer<T>.Default.GetHashCode(value!) : 0;
-
-    public override string ToString() => hasValue ? $"just {value}" : "nothing";
+    public abstract bool Equals(Maybe<T>? other);
 
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     public static implicit operator Maybe<T>(NothingMaybe _) => Nothing;
+
+
 }
 
 public static class Maybe
 {
     public static Maybe<T> FromNullable<T>(T? value) where T : class =>
-        value == null ? Nothing : Maybe<T>.Just(value);
+        value == null ? Nothing<T>() : Maybe<T>.Just(value);
 
     public static Maybe<T> FromNullable<T>(T? value) where T : struct =>
-        value.HasValue ? Maybe<T>.Just(value.Value) : Nothing;
+        value.HasValue ? Maybe<T>.Just(value.Value) : Nothing<T>();
 
     public static Maybe<T> Just<T>(T value) where T : notnull  => Maybe<T>.Just(value);
 
-    public static NothingMaybe Nothing => default;
+    public static Maybe<T> Nothing<T>() where T : notnull => Maybe<T>.Nothing;
 }
 
 public readonly struct NothingMaybe
 {
+}
+
+
+public class Nothing<T> : Maybe<T>
+    where T : notnull
+{
+    internal Nothing()
+    {
+    }
+
+
+    public override void Match(Action<T> _) { }
+
+    public override void Match(Action<T> _, Action onNothing) => onNothing();
+    public override TResult Match<TResult>(Func<T, TResult> _, Func<TResult> onNothing) => onNothing();
+
+
+    public override T ValueOrDefault(T @default) => @default;
+
+    public override T ValueOrDefault(Func<T> defaultProvider) => defaultProvider();
+
+    public override Result<T, TError> ValueOrFailure<TError>(TError error) => Result.Failure(error);
+
+    public override Result<T, TError> ValueOrFailure<TError>(Func<TError> errorProvider) => Result.Failure(errorProvider());
+
+    public override Maybe<TOut> Select<TOut>(Func<T, TOut> selector) => Maybe<TOut>.Nothing;
+
+    public override Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector) => Maybe<TOut>.Nothing;
+
+    public override Maybe<T> Where(Func<T, bool> predicate) => Nothing;
+
+
+    public override int GetHashCode() => 0;
+
+    public override string ToString() => "nothing";
+    public override bool Equals(Maybe<T>? other) => other is Nothing<T>;
+
+    public override bool Equals(object? obj) => obj is Maybe<T> other && Equals(other);
+
+}
+
+public class Just<T> : Maybe<T> where T : notnull
+{
+
+    protected readonly T value;
+
+    internal Just(T value)
+    {
+        this.value = value;
+    }
+    public override void Match(Action<T> onValue) => onValue(value!);
+    public override void Match(Action<T> onValue, Action _) => onValue(value!);
+    public override TResult Match<TResult>(Func<T, TResult> onValue, Func<TResult> _) => onValue(value!);
+
+    public override T ValueOrDefault(T @default) => value!;
+
+    public override T ValueOrDefault(Func<T> defaultProvider) => value!;
+
+    public override Result<T, TError> ValueOrFailure<TError>(TError _) =>  Result.Success(value!);
+
+    public override Result<T, TError> ValueOrFailure<TError>(Func<TError> _) => Result.Success(value!);
+
+    public override Maybe<TOut> Select<TOut>(Func<T, TOut> selector) => Maybe.Just(selector(value!));
+
+    public override Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector)  => selector(value!);
+
+    public override Maybe<T> Where(Func<T, bool> predicate) => predicate(value!) ? this : Nothing;
+
+
+    public override int GetHashCode() => EqualityComparer<T>.Default.GetHashCode(value!);
+
+    public override string ToString() => $"just {value}";
+
+    public bool Equals(Just<T> other) => EqualityComparer<T>.Default.Equals(value, other.value);
+    public override bool Equals(Maybe<T>? other) => other is Just<T> just && Equals(just);
+    public override bool Equals(object? obj) => obj is Maybe<T> other && Equals(other);
 }

--- a/Bearded.Utilities/Core/Maybe.cs
+++ b/Bearded.Utilities/Core/Maybe.cs
@@ -6,49 +6,49 @@ using Bearded.Utilities.Monads;
 namespace Bearded.Utilities;
 
 public readonly struct Maybe<T> : IEquatable<Maybe<T>>
+    where T : notnull
 {
-    private readonly bool hasValue;
-    private readonly T value;
+    private bool hasValue => value is not null;
+    private readonly T? value;
 
     private Maybe(T value)
     {
-        hasValue = true;
         this.value = value;
     }
 
     public static Maybe<T> Nothing => default;
 
-    internal static Maybe<T> Just(T value) => new Maybe<T>(value);
+    internal static Maybe<T> Just(T value) => new(value);
 
-    public T ValueOrDefault(T @default) => hasValue ? value : @default;
+    public T ValueOrDefault(T @default) => hasValue ? value! : @default;
 
-    public T ValueOrDefault(Func<T> defaultProvider) => hasValue ? value : defaultProvider();
+    public T ValueOrDefault(Func<T> defaultProvider) => hasValue ? value! : defaultProvider();
 
     public Result<T, TError> ValueOrFailure<TError>(TError error) =>
-        hasValue ? (Result<T, TError>) Result.Success(value) : Result.Failure(error);
+        hasValue ? (Result<T, TError>) Result.Success(value!) : Result.Failure(error);
 
     public Result<T, TError> ValueOrFailure<TError>(Func<TError> errorProvider) =>
-        hasValue ? (Result<T, TError>) Result.Success(value) : Result.Failure(errorProvider());
+        hasValue ? (Result<T, TError>) Result.Success(value!) : Result.Failure(errorProvider());
 
-    public Maybe<TOut> Select<TOut>(Func<T, TOut> selector) =>
-        hasValue ? Maybe.Just(selector(value)) : Maybe<TOut>.Nothing;
+    public Maybe<TOut> Select<TOut>(Func<T, TOut> selector) where TOut : notnull =>
+        hasValue ? Maybe.Just(selector(value!)) : Maybe<TOut>.Nothing;
 
-    public Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector) =>
-        hasValue ? selector(value) : Maybe<TOut>.Nothing;
+    public Maybe<TOut> SelectMany<TOut>(Func<T, Maybe<TOut>> selector) where TOut : notnull  =>
+        hasValue ? selector(value!) : Maybe<TOut>.Nothing;
 
-    public Maybe<T> Where(Func<T, bool> predicate) => hasValue && predicate(value) ? this : Nothing;
+    public Maybe<T> Where(Func<T, bool> predicate) => hasValue && predicate(value!) ? this : Nothing;
 
     public void Match(Action<T> onValue)
     {
         if (hasValue)
-            onValue(value);
+            onValue(value!);
     }
 
     public void Match(Action<T> onValue, Action onNothing)
     {
         if (hasValue)
         {
-            onValue(value);
+            onValue(value!);
         }
         else
         {
@@ -58,7 +58,7 @@ public readonly struct Maybe<T> : IEquatable<Maybe<T>>
 
     public TResult Match<TResult>(Func<T, TResult> onValue, Func<TResult> onNothing)
     {
-        return hasValue ? onValue(value) : onNothing();
+        return hasValue ? onValue(value!) : onNothing();
     }
 
     public bool Equals(Maybe<T> other) =>
@@ -66,7 +66,7 @@ public readonly struct Maybe<T> : IEquatable<Maybe<T>>
 
     public override bool Equals(object? obj) => obj is Maybe<T> other && Equals(other);
 
-    public override int GetHashCode() => hasValue ? EqualityComparer<T>.Default.GetHashCode(value) : 0;
+    public override int GetHashCode() => hasValue ? EqualityComparer<T>.Default.GetHashCode(value!) : 0;
 
     public override string ToString() => hasValue ? $"just {value}" : "nothing";
 
@@ -82,7 +82,7 @@ public static class Maybe
     public static Maybe<T> FromNullable<T>(T? value) where T : struct =>
         value.HasValue ? Maybe<T>.Just(value.Value) : Nothing;
 
-    public static Maybe<T> Just<T>(T value) => Maybe<T>.Just(value);
+    public static Maybe<T> Just<T>(T value) where T : notnull  => Maybe<T>.Just(value);
 
     public static NothingMaybe Nothing => default;
 }

--- a/Bearded.Utilities/Core/Singleton.cs
+++ b/Bearded.Utilities/Core/Singleton.cs
@@ -4,7 +4,7 @@ namespace Bearded.Utilities;
 
 public abstract class Singleton<TSelf> where TSelf : Singleton<TSelf>
 {
-    public static TSelf Instance { get; private set; }
+    public static TSelf? Instance { get; private set; }
 
     protected Singleton()
     {

--- a/Bearded.Utilities/Core/StaticRandom.cs
+++ b/Bearded.Utilities/Core/StaticRandom.cs
@@ -12,13 +12,13 @@ public static class StaticRandom
 {
     #region Threadsafe random
     [ThreadStatic]
-    private static Random random;
+    private static Random? random;
 
     /// <summary>
     /// The thread safe instance of Random used by StaticRandom
     /// </summary>
     // is internal for use as default random in Linq.Extensions
-    internal static Random Random => random ?? (random = new Random());
+    internal static Random Random => random ??= new Random();
 
     /// <summary>
     /// Overrides the Random object for the calling thread by one with the given seed.

--- a/Bearded.Utilities/IO/Logger.cs
+++ b/Bearded.Utilities/IO/Logger.cs
@@ -234,7 +234,7 @@ public class Logger
     /// <summary>
     /// If RaiseEvents is true, this event is raised every time an event is added to the log.
     /// </summary>
-    public event LogEvent Logged;
+    public event LogEvent? Logged;
 
     #region settings
 

--- a/Bearded.Utilities/Input/Actions/DigitalAction.cs
+++ b/Bearded.Utilities/Input/Actions/DigitalAction.cs
@@ -10,6 +10,6 @@ abstract class DigitalAction : IAction
     public float AnalogAmount => Active ? 1 : 0;
 
     public override bool Equals(object? obj) => Equals(obj as IAction);
-    public bool Equals(IAction other) => other is DigitalAction && this.IsSameAs(other);
+    public bool Equals(IAction? other) => other is DigitalAction && this.IsSameAs(other);
     public override int GetHashCode() => ToString()?.GetHashCode() ?? 0;
 }

--- a/Bearded.Utilities/Input/Actions/DummyAction.cs
+++ b/Bearded.Utilities/Input/Actions/DummyAction.cs
@@ -18,6 +18,6 @@ sealed class DummyAction : IAction
     public override string ToString() => name;
 
     public override bool Equals(object? obj) => Equals(obj as IAction);
-    public bool Equals(IAction other) => other is DummyAction && this.IsSameAs(other);
+    public bool Equals(IAction? other) => other is DummyAction && this.IsSameAs(other);
     public override int GetHashCode() => ToString().GetHashCode();
 }

--- a/Bearded.Utilities/Input/Actions/LambdaAction.cs
+++ b/Bearded.Utilities/Input/Actions/LambdaAction.cs
@@ -28,6 +28,6 @@ public static class DeferredAction
         public bool IsAnalog => action.IsAnalog;
         public float AnalogAmount => action.AnalogAmount;
 
-        public bool Equals(IAction other) => this.IsSameAs(other);
+        public bool Equals(IAction? other) => this.IsSameAs(other);
     }
 }

--- a/Bearded.Utilities/Input/InputAction.cs
+++ b/Bearded.Utilities/Input/InputAction.cs
@@ -9,7 +9,7 @@ namespace Bearded.Utilities.Input;
 
 public static class InputAction
 {
-    public static bool IsSameAs(this IAction me, IAction other)
+    public static bool IsSameAs(this IAction me, IAction? other)
         => other != null && (ReferenceEquals(me, other) || me.ToString() == other.ToString());
 
     public static IAction None { get; } = new DummyAction("unbound");
@@ -99,7 +99,7 @@ public static class InputAction
         public bool IsAnalog => Child1.IsAnalog || Child2.IsAnalog;
         public float AnalogAmount => FloatOp(Child1.AnalogAmount, Child2.AnalogAmount);
 
-        public bool Equals(IAction other) => this.IsSameAs(other);
+        public bool Equals(IAction? other) => this.IsSameAs(other);
     }
 
     private class OrAction : BinaryAction
@@ -130,6 +130,6 @@ public static class InputAction
         public bool IsAnalog => actions.Any(a => a.IsAnalog);
         public float AnalogAmount => actions.Max(a => a.AnalogAmount);
 
-        public bool Equals(IAction other) => this.IsSameAs(other);
+        public bool Equals(IAction? other) => this.IsSameAs(other);
     }
 }

--- a/Bearded.Utilities/Input/InputManager.Actions.Keyboard.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.Keyboard.cs
@@ -33,15 +33,15 @@ partial class InputManager
 
         public IAction FromKey(Keys key) => new KeyboardAction(manager, key);
 
-        public IAction FromString(string value)
+        public IAction? FromString(string value)
             => TryParse(value, out var action)
                 ? action
                 : throw new FormatException($"Keyboard key '{value}' invalid.");
 
-        public bool TryParse(string value, out IAction action)
+        public bool TryParse(string value, out IAction? action)
             => TryParseLowerTrimmedString(value.ToLowerInvariant().Trim(), out action);
 
-        internal bool TryParseLowerTrimmedString(string value, out IAction action)
+        internal bool TryParseLowerTrimmedString(string value, out IAction? action)
         {
             action = null;
 

--- a/Bearded.Utilities/Input/InputManager.Actions.cs
+++ b/Bearded.Utilities/Input/InputManager.Actions.cs
@@ -15,10 +15,10 @@ partial class InputManager
 
         public IAction None => InputAction.None;
 
-        public IAction FromString(string value)
+        public IAction? FromString(string value)
             => fromLowerCaseTrimmedString(value.ToLowerInvariant().Trim());
 
-        private IAction fromLowerCaseTrimmedString(string value)
+        private IAction? fromLowerCaseTrimmedString(string value)
         {
             switch (value)
             {

--- a/Bearded.Utilities/Linq/Extensions.cs
+++ b/Bearded.Utilities/Linq/Extensions.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 
 namespace Bearded.Utilities.Linq;
@@ -152,8 +153,13 @@ public static class Extensions
     /// <param name="result">The resulting transformed value.</param>
     /// <param name="transform">The function transforming the value into the result.</param>
     /// <returns>True if the value was found, false otherwise.</returns>
-    public static bool TryGetTransformedValue<TKey, TValue, TNewValue>(this Dictionary<TKey, TValue> dictionary, TKey key, out TNewValue result,
-        Func<TValue, TNewValue> transform)
+    public static bool TryGetTransformedValue<TKey, TValue, TNewValue>(
+        this Dictionary<TKey, TValue> dictionary,
+        TKey key,
+        [MaybeNullWhen(false)] out TNewValue result,
+        Func<TValue, TNewValue> transform
+    )
+        where TKey : notnull
     {
         if (dictionary.TryGetValue(key, out var value))
         {
@@ -171,7 +177,9 @@ public static class Extensions
     /// <param name="dictionary">The dictionary.</param>
     /// <param name="other">KeyValuePairs to add.</param>
     public static void AddRange<TKey, TValue>(this IDictionary<TKey, TValue> dictionary,
-        IEnumerable<KeyValuePair<TKey, TValue>> other)
+        IEnumerable<KeyValuePair<TKey, TValue>> other
+    )
+        where TKey : notnull
     {
         foreach (var pair in other)
         {
@@ -181,6 +189,7 @@ public static class Extensions
 
     public static TValue? ValueOrNull<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
         where TValue : class
+        where TKey : notnull
     {
         dict.TryGetValue(key, out var value);
         return value;
@@ -188,6 +197,7 @@ public static class Extensions
 
     public static TValue ValueOrDefault<TKey, TValue>(this Dictionary<TKey, TValue> dict, TKey key)
         where TValue : struct
+        where TKey : notnull
     {
         dict.TryGetValue(key, out var value);
         return value;

--- a/Bearded.Utilities/Monads/Result.cs
+++ b/Bearded.Utilities/Monads/Result.cs
@@ -14,11 +14,13 @@ public readonly struct Result<TResult, TError> : IEquatable<Result<TResult, TErr
 
     private Result(bool isSuccess, TResult? result, TError? error)
     {
-        if (isSuccess && result is null)
-            throw new ArgumentNullException(nameof(result), "Result cannot be null when isSuccess is true");
-
-        if (!isSuccess && error is null)
-            throw new ArgumentNullException(nameof(error), "Error cannot be null when isSuccess is false");
+        switch (isSuccess)
+        {
+            case true when result is null:
+                throw new ArgumentNullException(nameof(result), "Result cannot be null when isSuccess is true");
+            case false when error is null:
+                throw new ArgumentNullException(nameof(error), "Error cannot be null when isSuccess is false");
+        }
 
         this.isSuccess = isSuccess;
         this.result = result;
@@ -38,7 +40,7 @@ public readonly struct Result<TResult, TError> : IEquatable<Result<TResult, TErr
     public TResult ResultOrThrow(Func<TError, Exception> exceptionProvider) =>
         isSuccess ? result! : throw exceptionProvider(error!);
 
-    public Maybe<TResult> AsMaybe() => isSuccess ? Maybe.Just(result!) : Maybe.Nothing;
+    public Maybe<TResult> AsMaybe() => isSuccess ? Maybe.Just(result!) : Maybe.Nothing<TResult>();
 
     public Result<TOut, TError> Select<TOut>(Func<TResult, TOut> selector) where TOut : notnull  =>
         isSuccess ? (Result<TOut, TError>) Result.Success(selector(result!)) : Result.Failure(error!);


### PR DESCRIPTION

## ✨ What's this?
Removes all warnings related to nullable. Also made a more straight-forward implementation of `Maybe<T>`

### 🔗 Relationships
Closes #184 

## 🔍 Why do we want this?
Using explicit nullable is a move towards safer and more stable code.

## 🏗 How is it done?
Mostly went through all errors and fixes as I went along. `Maybe<T>` caused a bunch of trouble, so I remade the functionallity using an abstract main class (`Maybe<T>`) with two deriving classes (`Just<T>` and `Nothing<T>`). This separates the intent into two different classes, both simplifying the actual logic and prevents any casting/default issues.

### 💥 Breaking changes
Hopefully none. Tests are unchanged (and still full of warnings) to allow for insight into backwards compability.

## 💡 Review hints
Might be wasier to look at commits rather than full PR, especially for the change to `Maybe<T>`
