### PR TITLE
🧑‍🚒 Replace copied workflows with workflow references

### DIFF
--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -9,3 +9,8 @@ on:
 jobs:
   dotnet-build:
     uses: beardgame/.github/.github/workflows/dotnet-build.yml@main
+    with:
+      dotnet-version: |
+        3.1.x
+        5.0.x
+        6.0.x

--- a/.github/workflows/dotnet-build.yml
+++ b/.github/workflows/dotnet-build.yml
@@ -7,57 +7,5 @@ on:
     branches: [ master ]
 
 jobs:
-  build:
-
-    name: Build & Test
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3.2.0
-        with:
-          dotnet-version: |
-            3.1.x
-            5.0.x
-            6.0.x
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build -c Release --no-restore
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
-
-  benchmark:
-
-    name: Run benchmarks
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3.2.0
-        with:
-          dotnet-version: 6.0.x
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build -c Release --no-restore
-      - name: Run benchmarks
-        run: dotnet run --project Bearded.Utilities.Benchmarks -c Release --no-build -- -f '*' --join --exporters json
-      - name: Copy benchmark data to deterministic location
-        run: cp BenchmarkDotNet.Artifacts/results/*-report-full-compressed.json ./new-benchmark-data.json
-      - name: Download previous benchmark data
-        uses: actions/cache@v3
-        with:
-          path: ./benchmarks
-          key: ${{ runner.os }}-benchmark-v2
-      - name: Process benchmark result
-        uses: Happypig375/github-action-benchmark@v1.8.2
-        with:
-          tool: 'benchmarkdotnet'
-          output-file-path: ./new-benchmark-data.json
-          external-data-json-path: ./benchmarks/benchmark-data.json
-          fail-on-alert: true
-          comment-on-alert: true
-          github-token: ${{ secrets.GITHUB_TOKEN }}
+  dotnet-build:
+    uses: beardgame/.github/.github/workflows/dotnet-build.yml@main

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -6,54 +6,8 @@ on:
       - v*
 
 jobs:
-  publish:
-
-    name: Publish
-    runs-on: ubuntu-latest
-
-    steps:
-      # Build library and run tests
-      - uses: actions/checkout@v3
-      - name: Setup .NET
-        uses: actions/setup-dotnet@v3.2.0
-        with:
-          dotnet-version: |
-            3.1.x
-            5.0.x
-            6.0.x
-      - name: Install dependencies
-        run: dotnet restore
-      - name: Build
-        run: dotnet build --configuration Release --no-restore
-      - name: Test
-        run: dotnet test --no-restore --verbosity normal
-
-      # Set up environment variables
-      # The version number can be extracted from the currently checked out tag,
-      # which has the format 'refs/tags/v*'.
-      - name: Extract version number
-        run: echo "RELEASE_VERSION=${GITHUB_REF#refs/*/}" >> $GITHUB_ENV
-
-      # Create the NuGet package
-      # Note that we substr the release version to get the numbers only, without
-      # the 'v' prefix.
-      - name: Pack Bearded.Utilities
-        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Utilities/Bearded.Utilities.csproj
-      - name: Pack Bearded.Utilities.Testing
-        run: dotnet pack --configuration Release --no-restore -p:PackageVersion=${RELEASE_VERSION:1} Bearded.Utilities.Testing/Bearded.Utilities.Testing.csproj
-
-      # Create a GitHub release
-      - name: Create a Release
-        uses: softprops/action-gh-release@v1
-        with:
-          tag_name: ${{ env.RELEASE_VERSION }}
-          name: Release ${{ env.RELEASE_VERSION }}
-          draft: false
-          prerelease: ${{ contains(env.RELEASE_VERSION, '-') }}
-          generate_release_notes: true
-          token: ${{ secrets.GITHUB_TOKEN }}
-          files: "**/*.nupkg"
-
-      # Push the NuGet package to the package providers
-      - name: Push release to NuGet
-        run: dotnet nuget push **/*.nupkg --source https://api.nuget.org/v3/index.json -k ${{ secrets.NUGET_API_KEY }} --skip-duplicate
+  dotnet-publish:
+    uses: beardgame/.github/.github/workflows/dotnet-publish.yml@main
+    secrets:
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}

--- a/.github/workflows/dotnet-publish.yml
+++ b/.github/workflows/dotnet-publish.yml
@@ -8,6 +8,11 @@ on:
 jobs:
   dotnet-publish:
     uses: beardgame/.github/.github/workflows/dotnet-publish.yml@main
+    with:
+      dotnet-version: |
+        3.1.x
+        5.0.x
+        6.0.x
     secrets:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}


### PR DESCRIPTION
## ✨ What's this?
This PR replaces the copy of the workflow templates from beardgame/.github with a much simpler one that refers to the files in that same repository, so they automatically pick up any changes.

## 🔍 Why do we want this?
It saves on duplication.

## 🏗 How is it done?
Manually porting over the `jobs` section of the yaml files.
