### PR TITLE
🫂 Group xUnit and OpenTK dependabot upgrades

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,8 +9,17 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "⬆"
-    assignees:
+    reviewers:
       - "tomrijnbeek"
+    groups:
+      # Always update all OpenTK dependencies together to keep them in sync
+      opentk:
+        patterns:
+          - "OpenTK*"
+      # Always update all xUnit dependencies together since they always release together
+      xunit:
+        patterns:
+          - "xunit*"
 
   - package-ecosystem: "github-actions"
     # Workflow files stored in the
@@ -20,5 +29,5 @@ updates:
       interval: "daily"
     commit-message:
       prefix: "⬆"
-    assignees:
+    reviewers:
       - "tomrijnbeek"


### PR DESCRIPTION
## ✨ What's this?
This instructs dependabot to always combine upgrades within the xUnit and OpenTK groups (separately). 

## 🔍 Why do we want this?
We have multiple dependencies, but they tend to be released together. This avoids version conflicts.

## 🏗 How is it done?
Reused the config from TD and audio, both of which have proven to be successful in achieving the desired behaviour.

## 💡 Review hints
I've also modified "assignee" to "reviewer", since that's what I _actually_ end up doing for these PRs 😁 
