### PR TITLE
🐛 Fix Rectangle.FromSides creation

### DIFF
--- a/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
+++ b/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
@@ -13,6 +13,5 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bearded.Utilities.Testing\Bearded.Utilities.Testing.csproj" />
-    <ProjectReference Include="..\Bearded.Utilities\Bearded.Utilities.csproj" />
   </ItemGroup>
 </Project>

--- a/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
+++ b/Bearded.Utilities.Testing.Tests/Bearded.Utilities.Testing.Tests.csproj
@@ -13,5 +13,6 @@
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Bearded.Utilities.Testing\Bearded.Utilities.Testing.csproj" />
+    <ProjectReference Include="..\Bearded.Utilities\Bearded.Utilities.csproj" />
   </ItemGroup>
 </Project>

--- a/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
+++ b/Bearded.Utilities.Tests/Bearded.Utilities.Tests.csproj
@@ -3,7 +3,7 @@
     <LangVersion>10</LangVersion>
     <Nullable>enable</Nullable>
     <WarningsAsErrors>CS8600;CS8602;CS8603</WarningsAsErrors>
-    <TargetFrameworks>net5.0;net6.0;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net6.0;netcoreapp3.1</TargetFrameworks>
   </PropertyGroup>
   <ItemGroup>
     <PackageReference Include="FluentAssertions" Version="6.12.0" />

--- a/Bearded.Utilities.Tests/Geometry/RectangleTest.cs
+++ b/Bearded.Utilities.Tests/Geometry/RectangleTest.cs
@@ -1,0 +1,74 @@
+﻿using System;
+using Bearded.Utilities.Geometry;
+using Bearded.Utilities.Tests.Generators;
+using FluentAssertions;
+using FsCheck.Xunit;
+using OpenTK.Mathematics;
+
+namespace Bearded.Utilities.Tests.Geometry;
+
+public sealed class RectangleTest
+{
+    private const float epsilon = 0.01f;
+
+    [Property(Arbitrary = new[] { typeof(FloatGenerators.ForArithmetic) })]
+    public void RectangleMadeFromXyWidthHeightHasCorrectDimensions(float x, float y, float w, float h)
+    {
+        if (w < 0) w *= -1;
+        if (h < 0) h *= -1;
+
+        var rectangle = new Rectangle(x, y, w, h);
+
+        // from input
+        rectangle.Left.Should().BeApproximately(x, epsilon);
+        rectangle.Top.Should().BeApproximately(y, epsilon);
+        rectangle.Width.Should().BeApproximately(w, epsilon);
+        rectangle.Height.Should().BeApproximately(h, epsilon);
+
+        // derived
+        rectangle.Right.Should().BeApproximately(x + w, epsilon);
+        rectangle.Bottom.Should().BeApproximately(y + h, epsilon);
+    }
+
+    [Property(Arbitrary = new[] { typeof(FloatGenerators.ForArithmetic) })]
+    public void RectangleMadeFromSidesHasCorrectDimensions(float x1, float x2, float y1, float y2)
+    {
+        var top = Math.Min(y1, y2);
+        var right = Math.Max(x1, x2);
+        var bottom = Math.Max(y1, y2);
+        var left = Math.Min(x1, x2);
+
+        var rectangle = Rectangle.WithSides(top, right, bottom, left);
+
+        // from input
+        rectangle.Top.Should().BeApproximately(top, epsilon);
+        rectangle.Right.Should().BeApproximately(right, epsilon);
+        rectangle.Bottom.Should().BeApproximately(bottom, epsilon);
+        rectangle.Left.Should().BeApproximately(left, epsilon);
+
+        // derived
+        rectangle.Width.Should().BeApproximately(right - left, epsilon);
+        rectangle.Height.Should().BeApproximately(bottom - top, epsilon);
+    }
+
+    [Property(Arbitrary = new[] { typeof(FloatGenerators.ForArithmetic) })]
+    public void RectangleMadeFromCornersHasCorrectDimensions(float x1, float x2, float y1, float y2)
+    {
+        var top = Math.Min(y1, y2);
+        var right = Math.Max(x1, x2);
+        var bottom = Math.Max(y1, y2);
+        var left = Math.Min(x1, x2);
+
+        var rectangle = Rectangle.WithCorners(new Vector2(left, top), new Vector2(right, bottom));
+
+        // from input
+        rectangle.Top.Should().BeApproximately(top, epsilon);
+        rectangle.Right.Should().BeApproximately(right, epsilon);
+        rectangle.Bottom.Should().BeApproximately(bottom, epsilon);
+        rectangle.Left.Should().BeApproximately(left, epsilon);
+
+        // derived
+        rectangle.Width.Should().BeApproximately(right - left, epsilon);
+        rectangle.Height.Should().BeApproximately(bottom - top, epsilon);
+    }
+}

--- a/Bearded.Utilities/Geometry/Rectangle.cs
+++ b/Bearded.Utilities/Geometry/Rectangle.cs
@@ -19,12 +19,12 @@ public readonly struct Rectangle : IEquatable<Rectangle>, IFormattable
     public float Right => Left + Width;
     public float Bottom => Top + Height;
 
-    public Vector2 TopLeft => new Vector2(Left, Top);
-    public Vector2 TopRight => new Vector2(Right, Top);
-    public Vector2 BottomLeft => new Vector2(Left, Bottom);
-    public Vector2 BottomRight => new Vector2(Right, Bottom);
+    public Vector2 TopLeft => new(Left, Top);
+    public Vector2 TopRight => new(Right, Top);
+    public Vector2 BottomLeft => new(Left, Bottom);
+    public Vector2 BottomRight => new(Right, Bottom);
 
-    public Vector2 Center => new Vector2(Left + Width * 0.5f, Top + Height * 0.5f);
+    public Vector2 Center => new(Left + Width * 0.5f, Top + Height * 0.5f);
 
     public float Area => Width * Height;
 
@@ -56,10 +56,10 @@ public readonly struct Rectangle : IEquatable<Rectangle>, IFormattable
             || other.Top > Bottom || other.Bottom < Top);
 
     public static Rectangle WithCorners(Vector2 upperLeft, Vector2 bottomRight)
-        => new Rectangle(upperLeft.X, upperLeft.Y, bottomRight.X - upperLeft.X, bottomRight.Y - upperLeft.Y);
+        => new(upperLeft.X, upperLeft.Y, bottomRight.X - upperLeft.X, bottomRight.Y - upperLeft.Y);
 
-    public static Rectangle WithSides(float top, float right, float bottom, float left)
-        => new Rectangle(top, left, bottom - top, right - left);
+    public static Rectangle WithSides(float top, float right, float bottom, float left) =>
+        new(left, top, right - left, bottom - top);
 
     public bool Equals(Rectangle other)
         // ReSharper disable CompareOfFloatsByEqualityOperator


### PR DESCRIPTION
## ✨ What's this?
This PR fixes the `Rectangle.FromSides` method to create the correct rectangle. Right now it has the X and Y dimensions flipped.

## 🔍 Why do we want this?
To have correctly oriented rectangles.

## 🏗 How is it done?
First added a test case to reproduce the bug, then fixed it. Also added some other basic test cases for similar code paths for consistency. We could be testing `Rectangle` much more but that was not the intent of this PR.

### 💥 Breaking changes
If people considered this a feature... they really shouldn't

### 🦋 Side effects
I disabled the .NET 5 tests since .NET 5 is no longer supported and it wouldn't run locally on my machine. We should probably stop supporting it altogether but I'll leave that to a separate PR.