### PR TITLE
⬇️ Downgrade System.Collections.Immutable

### DIFF
--- a/Bearded.Utilities.Tests/Algorithms/CoffmanGrahamTests.cs
+++ b/Bearded.Utilities.Tests/Algorithms/CoffmanGrahamTests.cs
@@ -133,7 +133,7 @@ public class CoffmanGrahamTests
 
         var solution = solver.Solve(graph);
 
-        for (var i = 0; i < solution.Count; i++)
+        for (var i = 0; i < solution.Length; i++)
         {
             solution[i].Should().ContainSingle().Which.Should().Be(i);
         }

--- a/Bearded.Utilities/Algorithms/CoffmanGraham.cs
+++ b/Bearded.Utilities/Algorithms/CoffmanGraham.cs
@@ -37,7 +37,7 @@ public static class CoffmanGraham
 {
     public interface ISolver
     {
-        ImmutableList<ImmutableHashSet<T>> Solve<T>(IDirectedAcyclicGraph<T> graph)
+        ImmutableArray<ImmutableHashSet<T>> Solve<T>(IDirectedAcyclicGraph<T> graph)
             where T : IEquatable<T>;
     }
 
@@ -50,7 +50,7 @@ public static class CoffmanGraham
             internalSolver = new ReducedGraphSolver(maxLayerSize);
         }
 
-        public ImmutableList<ImmutableHashSet<T>> Solve<T>(IDirectedAcyclicGraph<T> graph)
+        public ImmutableArray<ImmutableHashSet<T>> Solve<T>(IDirectedAcyclicGraph<T> graph)
             where T : IEquatable<T>
         {
             var reducedGraph = DirectedAcyclicGraphTransitiveReducer<T>.ReduceGraph(graph);
@@ -67,10 +67,10 @@ public static class CoffmanGraham
             this.maxLayerSize = maxLayerSize;
         }
 
-        public ImmutableList<ImmutableHashSet<T>> Solve<T>(IDirectedAcyclicGraph<T> graph)
+        public ImmutableArray<ImmutableHashSet<T>> Solve<T>(IDirectedAcyclicGraph<T> graph)
             where T : IEquatable<T>
         {
-            if (graph.Count == 0) return ImmutableList<ImmutableHashSet<T>>.Empty;
+            if (graph.Count == 0) return ImmutableArray<ImmutableHashSet<T>>.Empty;
 
             var ordering = createTopologicalOrdering(graph);
             return createLayers(graph, ordering, maxLayerSize);
@@ -125,7 +125,7 @@ public static class CoffmanGraham
             }
         }
 
-        private static ImmutableList<ImmutableHashSet<T>> createLayers<T>(
+        private static ImmutableArray<ImmutableHashSet<T>> createLayers<T>(
             // ReSharper disable once SuggestBaseTypeForParameter
             IDirectedAcyclicGraph<T> graph, IList<T> ordering, int maxLayerSize)
             where T : IEquatable<T>
@@ -169,7 +169,7 @@ public static class CoffmanGraham
                 elementToLayer.Add(ordering[i], candidateLayer);
             }
 
-            return ImmutableList.CreateRange(layersReversed.Select(b => b.ToImmutable()).Reverse());
+            return ImmutableArray.CreateRange(layersReversed.Select(b => b.ToImmutable()).Reverse());
         }
     }
 

--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="OpenTK.Mathematics" Version="4.8.2" />
     <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.8.2" />
     <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.8.2" />
-    <PackageReference Include="System.Collections.Immutable" Version="8.0.0" />
+    <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.0.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />
   </ItemGroup>

--- a/Bearded.Utilities/Graphs/AdjacencyListDirectedAcyclicGraph.cs
+++ b/Bearded.Utilities/Graphs/AdjacencyListDirectedAcyclicGraph.cs
@@ -7,9 +7,9 @@ sealed class AdjacencyListDirectedAcyclicGraph<T> : AdjacencyListDirectedGraph<T
     where T : IEquatable<T>
 {
     internal AdjacencyListDirectedAcyclicGraph(
-        ImmutableList<T> elements,
-        ImmutableDictionary<T, ImmutableList<T>> directSuccessors,
-        ImmutableDictionary<T, ImmutableList<T>> directPredecessors)
+        ImmutableArray<T> elements,
+        ImmutableDictionary<T, ImmutableArray<T>> directSuccessors,
+        ImmutableDictionary<T, ImmutableArray<T>> directPredecessors)
         : base(
             elements,
             directSuccessors,

--- a/Bearded.Utilities/Graphs/AdjacencyListDirectedGraph.cs
+++ b/Bearded.Utilities/Graphs/AdjacencyListDirectedGraph.cs
@@ -6,17 +6,17 @@ namespace Bearded.Utilities.Graphs;
 
 class AdjacencyListDirectedGraph<T> : IDirectedGraph<T> where T : IEquatable<T>
 {
-    private readonly ImmutableList<T> elements;
-    private readonly ImmutableDictionary<T, ImmutableList<T>> directSuccessors;
-    private readonly ImmutableDictionary<T, ImmutableList<T>> directPredecessors;
+    private readonly ImmutableArray<T> elements;
+    private readonly ImmutableDictionary<T, ImmutableArray<T>> directSuccessors;
+    private readonly ImmutableDictionary<T, ImmutableArray<T>> directPredecessors;
 
     public IEnumerable<T> Elements => elements;
-    public int Count => elements.Count;
+    public int Count => elements.Length;
 
     internal AdjacencyListDirectedGraph(
-        ImmutableList<T> elements,
-        ImmutableDictionary<T, ImmutableList<T>> directSuccessors,
-        ImmutableDictionary<T, ImmutableList<T>> directPredecessors)
+        ImmutableArray<T> elements,
+        ImmutableDictionary<T, ImmutableArray<T>> directSuccessors,
+        ImmutableDictionary<T, ImmutableArray<T>> directPredecessors)
     {
         this.elements = elements;
         this.directSuccessors = directSuccessors;

--- a/Bearded.Utilities/Graphs/DirectedGraphBuilder.cs
+++ b/Bearded.Utilities/Graphs/DirectedGraphBuilder.cs
@@ -7,10 +7,10 @@ namespace Bearded.Utilities.Graphs;
 
 public sealed class DirectedGraphBuilder<T> where T : IEquatable<T>
 {
-    private readonly HashSet<T> elements = new HashSet<T>();
-    private readonly HashSet<T> sources = new HashSet<T>();
-    private readonly Dictionary<T, HashSet<T>> directSuccessors = new Dictionary<T, HashSet<T>>();
-    private readonly Dictionary<T, HashSet<T>> directPredecessors = new Dictionary<T, HashSet<T>>();
+    private readonly HashSet<T> elements = new();
+    private readonly HashSet<T> sources = new();
+    private readonly Dictionary<T, HashSet<T>> directSuccessors = new();
+    private readonly Dictionary<T, HashSet<T>> directPredecessors = new();
 
     public static DirectedGraphBuilder<T> NewBuilder()
     {
@@ -139,12 +139,12 @@ public sealed class DirectedGraphBuilder<T> where T : IEquatable<T>
     public IDirectedAcyclicGraph<T> CreateAcyclicGraphUnsafe()
     {
         return new AdjacencyListDirectedAcyclicGraph<T>(
-            ImmutableList.CreateRange(elements),
+            ImmutableArray.CreateRange(elements),
             directSuccessors.ToImmutableDictionary(
                 pair => pair.Key,
-                pair => ImmutableList.CreateRange(pair.Value)),
+                pair => ImmutableArray.CreateRange(pair.Value)),
             directPredecessors.ToImmutableDictionary(
                 pair => pair.Key,
-                pair => ImmutableList.CreateRange(pair.Value)));
+                pair => ImmutableArray.CreateRange(pair.Value)));
     }
 }

--- a/Bearded.Utilities/Graphs/DirectedGraphBuilder.cs
+++ b/Bearded.Utilities/Graphs/DirectedGraphBuilder.cs
@@ -81,13 +81,13 @@ public sealed class DirectedGraphBuilder<T> where T : IEquatable<T>
     public IDirectedGraph<T> CreateGraph()
     {
         return new AdjacencyListDirectedGraph<T>(
-            ImmutableList.CreateRange(elements),
+            ImmutableArray.CreateRange(elements),
             directSuccessors.ToImmutableDictionary(
                 pair => pair.Key,
-                pair => ImmutableList.CreateRange(pair.Value)),
+                pair => ImmutableArray.CreateRange(pair.Value)),
             directPredecessors.ToImmutableDictionary(
                 pair => pair.Key,
-                pair => ImmutableList.CreateRange(pair.Value)));
+                pair => ImmutableArray.CreateRange(pair.Value)));
     }
 
     /// <summary>


### PR DESCRIPTION
## ✨ What's this?
This PR downgrades the `System.Collections.Immutable` reference to 6.0.0.

It also replaces some references to `ImmutableList` to `ImmutableArray` which is a more appropriate data structures in our use cases.

## 🔍 Why do we want this?
`System.Collections.Immutable` isn't a "true" NuGet package. Rather it is part of the .NET runtime. Therefore, as long as we support .NET 6, we should stick with the current version.

Now... why not drop .NET 6 support you might ask? Well, because the Roslyn Source Generators in Rider completely break down if you target a runtime newer than .NET 6. If we want to be able to keep using types from `Bearded.Utilities` in binaries referenced by source generators (for example, in TD we use `Id<T>`) we will want to stick with .NET 6 for now.

One change to consider is to split the complex types, such as the algorithms and data structures, from the simpler stuff, so that it becomes easier to access some of the more atomic types (which could target a relatively low .NET version because we use no advanced features) without needing to pull in the bigger dependencies needed for complex code.

The change from `ImmutableList` to `ImmutableArray` is to ensure that access by index is a constant time operation.

## 🏗 How is it done?
Manual replacement in VS Code.

### 💥 Breaking changes
There is only one case where the public API used `ImmutableList`, that is the return type of `CoffmanGraham`. If you only rely on that being a collection anyway, code should remain compatible when recompiling (less likely to be binary compatible).