### PR TITLE
⬇️ Downgrade opentk to be compatible with other Bearded libraries

### DIFF
--- a/Bearded.Utilities/Bearded.Utilities.csproj
+++ b/Bearded.Utilities/Bearded.Utilities.csproj
@@ -12,10 +12,10 @@
     <SuppressTfmSupportBuildWarnings>true</SuppressTfmSupportBuildWarnings>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="OpenTK.Core" Version="4.9.3" />
-    <PackageReference Include="OpenTK.Mathematics" Version="4.9.3" />
-    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.9.3" />
-    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.9.3" />
+    <PackageReference Include="OpenTK.Core" Version="4.8.2" />
+    <PackageReference Include="OpenTK.Mathematics" Version="4.8.2" />
+    <PackageReference Include="OpenTK.Windowing.Desktop" Version="4.8.2" />
+    <PackageReference Include="OpenTK.Windowing.GraphicsLibraryFramework" Version="4.8.2" />
     <PackageReference Include="System.Collections.Immutable" Version="6.0.0" />
     <PackageReference Include="System.Runtime.CompilerServices.Unsafe" Version="6.1.0" />
     <PackageReference Include="System.ValueTuple" Version="4.5.0" />


### PR DESCRIPTION
## ✨ What's this?
This PR reverts #364 as other Bearded libraries still only use 3.8.x.

## 🔍 Why do we want this?
The 3.8.x and 3.9.x OpenTK versions are incompatible with each other. Despite being breaking changes, OpenTK team decided to stick with 3.x.x versioning since they have already been working on OpenTK 4 in the background, but it breaks semantic versioning.

Migrating all our libraries to 3.9.x seemed to cause some problems based on some quick experimentation. This is the fastest way to bring back TD to a functioning state.